### PR TITLE
Uses `git checkout` instead of `git reset` for `spack_commit` checkout

### DIFF
--- a/uberenv.py
+++ b/uberenv.py
@@ -428,7 +428,7 @@ def main():
             sha1 = project_opts["spack_commit"]
             print "[info: using spack commit %s]" % sha1
             os.chdir(pjoin(dest_dir,"spack"))
-            sexe("git reset --hard %s" % sha1,echo=True)
+            sexe("git checkout %s" % sha1,echo=True)
 
     if opts["spack_pull"]:
         # do a pull to make sure we have the latest


### PR DESCRIPTION
Resolves #8.