### PR TITLE
Feature: no fake package

### DIFF
--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -1,45 +1,45 @@
 .. ############################################################################
 .. # Copyright (c) 2014-2018, Lawrence Livermore National Security, LLC.
-.. # 
+.. #
 .. # Produced at the Lawrence Livermore National Laboratory
-.. # 
+.. #
 .. # LLNL-CODE-666778
-.. # 
+.. #
 .. # All rights reserved.
-.. # 
-.. # This file is part of Conduit. 
-.. # 
+.. #
+.. # This file is part of Conduit.
+.. #
 .. # For details, see: http://software.llnl.gov/conduit/.
-.. # 
+.. #
 .. # Please also read conduit/LICENSE
-.. # 
-.. # Redistribution and use in source and binary forms, with or without 
+.. #
+.. # Redistribution and use in source and binary forms, with or without
 .. # modification, are permitted provided that the following conditions are met:
-.. # 
-.. # * Redistributions of source code must retain the above copyright notice, 
+.. #
+.. # * Redistributions of source code must retain the above copyright notice,
 .. #   this list of conditions and the disclaimer below.
-.. # 
+.. #
 .. # * Redistributions in binary form must reproduce the above copyright notice,
 .. #   this list of conditions and the disclaimer (as noted below) in the
 .. #   documentation and/or other materials provided with the distribution.
-.. # 
+.. #
 .. # * Neither the name of the LLNS/LLNL nor the names of its contributors may
 .. #   be used to endorse or promote products derived from this software without
 .. #   specific prior written permission.
-.. # 
+.. #
 .. # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 .. # AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 .. # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
 .. # ARE DISCLAIMED. IN NO EVENT SHALL LAWRENCE LIVERMORE NATIONAL SECURITY,
 .. # LLC, THE U.S. DEPARTMENT OF ENERGY OR CONTRIBUTORS BE LIABLE FOR ANY
-.. # DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+.. # DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
 .. # DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
 .. # OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-.. # HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+.. # HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
 .. # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
-.. # IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+.. # IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 .. # POSSIBILITY OF SUCH DAMAGE.
-.. # 
+.. #
 .. ############################################################################
 
 .. _building_with_uberenv:
@@ -50,7 +50,7 @@ Uberenv
 **Uberenv** automates using `Spack <ttp://www.spack.io>`_ to build and deploy software.
 
 Many projects leverage `Spack <ttp://www.spack.io>`_ to help build the software dependencies needed to develop and deploy their projects on HPC systems. Uberenv is a python script that helps automate using Spack to build
-third-party dependencies for development and to deploy Spack packages. 
+third-party dependencies for development and to deploy Spack packages.
 
 Uberenv was released as part of Conduit (https://github.com/LLNL/conduit/). It is included in-source in several projects. The
 https://github.com/llnl/uberenv/ repo is used to hold the latest reference version of Uberenv.
@@ -70,7 +70,7 @@ https://github.com/LLNL/conduit/tree/master/scripts/uberenv
 ``uberenv.py`` is developed by LLNL in support of the `Ascent <http://github.com/alpine-dav/ascent/>`_, Axom, and `Conduit <https://github.com/llnl/conduit>`_  projects.
 
 
-Command Line Options 
+Command Line Options
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Build configuration
@@ -88,7 +88,7 @@ Build configuration
                                                                       osx: ``scripts/uberenv/spack_configs/darwin/``
   -k                   Ignore SSL Errors                              **False**
   --install            Fully install target, not just dependencies    **False**
-  --run_tests          Invoke tests during build and against install  **False** 
+  --run_tests          Invoke tests during build and against install  **False**
   --project-json       File for project specific settings             ``project.json``
  ==================== ============================================== ================================================
 
@@ -107,7 +107,7 @@ Default invocation on Linux:
 .. code:: bash
 
     python scripts/uberenv/uberenv.py --prefix uberenv_libs \
-                                      --spec %gcc 
+                                      --spec %gcc
 
 Default invocation on OSX:
 
@@ -144,9 +144,9 @@ documentation for details.
     The bootstrapping process ignores ``~/.spack/compilers.yaml`` to avoid conflicts
     and surprises from a user's specific Spack settings on HPC platforms.
 
-When run, ``uberenv.py`` checkouts a specific version of Spack from github as ``spack`` in the 
-destination directory. It then uses Spack to build and install the target packages' dependencies into 
-``spack/opt/spack/``. Finally, the target package generates a host-config file ``{hostname}.cmake``, which is 
+When run, ``uberenv.py`` checkouts a specific version of Spack from github as ``spack`` in the
+destination directory. It then uses Spack to build and install the target packages' dependencies into
+``spack/opt/spack/``. Finally, the target package generates a host-config file ``{hostname}.cmake``, which is
 copied to destination directory. This file specifies the compiler settings and paths to all of the dependencies.
 
 Project configuration
@@ -181,7 +181,7 @@ Optimization
  ==================== ============================================== ================================================
 
 
-Project Settings 
+Project Settings
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 A few notes on using ``uberenv.py`` in a new project:

--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -78,19 +78,19 @@ Build configuration
 
 ``uberenv.py`` has a few options that allow you to control how dependencies are built:
 
- ==================== ============================================== ================================================
-  Option               Description                                     Default
- ==================== ============================================== ================================================
-  --prefix             Destination directory                          ``uberenv_libs``
-  --spec               Spack spec                                     linux: **%gcc**
-                                                                      osx: **%clang**
-  --spack-config-dir   Folder with Spack settings files               linux: (empty)
-                                                                      osx: ``scripts/uberenv/spack_configs/darwin/``
-  -k                   Ignore SSL Errors                              **False**
-  --install            Fully install target, not just dependencies    **False**
-  --run_tests          Invoke tests during build and against install  **False**
-  --project-json       File for project specific settings             ``project.json``
- ==================== ============================================== ================================================
+ ======================= ============================================== ================================================
+  Option                  Description                                    Default
+ ======================= ============================================== ================================================
+  ``--prefix``            Destination directory                          ``uberenv_libs``
+  ``--spec``              Spack spec                                     linux: **%gcc**
+                                                                         osx: **%clang**
+  ``--spack-config-dir``  Folder with Spack settings files               linux: (empty)
+                                                                         osx: ``scripts/uberenv/spack_configs/darwin/``
+  ``-k``                  Ignore SSL Errors                              **False**
+  ``--install``           Fully install target, not just dependencies    **False**
+  ``--run_tests``         Invoke tests during build and against install  **False**
+  ``--project-json``      File for project specific settings             ``project.json``
+ ======================= ============================================== ================================================
 
 The ``-k`` option exists for sites where SSL certificate interception undermines fetching
 from github and https hosted source tarballs. When enabled, ``uberenv.py`` clones Spack using:
@@ -149,22 +149,23 @@ destination directory. It then uses Spack to build and install the target packag
 ``spack/opt/spack/``. Finally, the target package generates a host-config file ``{hostname}.cmake``, which is
 copied to destination directory. This file specifies the compiler settings and paths to all of the dependencies.
 
+
 Project configuration
 ---------------------
 
 Part of the configuration can also be addressed using a json file. By default, it is named ``project.json`` and some settings can be overridden on command line:
 
- ==================== ======================= ================================================ =======================================
-  Setting              Option                  Description                                      Default
- ==================== ======================= ================================================ =======================================
-  package_name         --package-name          Spack package name                               **None**
-  package_version      **None**                Spack package version                            **None**
-  package_final_phase  --package-final-phase   Controls after which phase Spack should stop     **None**
-  package_source_dir   --package-source-dir    Controls the source directory Spack should use   **None**
-  spack_url            **None**                Url where to download Spack                      ``https://github.com/spack/spack.git``
-  spack_commit         **None**                Spack commit to checkout                         **None**
-  spack_activate       **None**                Spack packages to activate                       **None**
- ==================== ======================= ================================================ =======================================
+ ==================== ========================== ================================================ =======================================
+  Setting              Option                     Description                                      Default
+ ==================== ========================== ================================================ =======================================
+  package_name         ``--package-name``         Spack package name                               **None**
+  package_version      **None**                   Spack package version                            **None**
+  package_final_phase  ``--package-final-phase``  Controls after which phase Spack should stop     **None**
+  package_source_dir   ``--package-source-dir``   Controls the source directory Spack should use   **None**
+  spack_url            **None**                   Url where to download Spack                      ``https://github.com/spack/spack.git``
+  spack_commit         **None**                   Spack commit to checkout                         **None**
+  spack_activate       **None**                   Spack packages to activate                       **None**
+ ==================== ========================== ================================================ =======================================
 
 
 Optimization
@@ -173,11 +174,11 @@ Optimization
 ``uberenv.py`` also features options to optimize the installation
 
  ==================== ============================================== ================================================
-  Option               Description                                     Default
+  Option               Description                                    Default
  ==================== ============================================== ================================================
-  --mirror             Location of a Spack mirror                     **None**
-  --create-mirror      Creates a Spack mirror at specified location   **None**
-  --upstream           Location of a Spack upstream                   **None**
+  ``--mirror``         Location of a Spack mirror                     **None**
+  ``--create-mirror``  Creates a Spack mirror at specified location   **None**
+  ``--upstream``       Location of a Spack upstream                   **None**
  ==================== ============================================== ================================================
 
 

--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -59,7 +59,7 @@ https://github.com/llnl/uberenv/ repo is used to hold the latest reference versi
 uberenv.py
 ~~~~~~~~~~~~~~~~~~~~~
 
-``uberenv.py`` is a single file python script that automates fetching spack, building and installing third party dependencies, and can optionally install packages as well.  To automate the full install process, ``uberenv.py`` uses a target Spack package along with extra settings such as Spack compiler and external third party package details for common HPC platforms.
+``uberenv.py`` is a single file python script that automates fetching Spack, building and installing third party dependencies, and can optionally install packages as well.  To automate the full install process, ``uberenv.py`` uses a target Spack package along with extra settings such as Spack compiler and external third party package details for common HPC platforms.
 
 ``uberenv.py`` is included directly in a project's source code repo in the folder: ``scripts/uberenv/``
 This folder is also used to store extra Spack and Uberenv configuration files unique to the target project. ``uberenv.py`` uses a ``project.json`` file to specify project details, including the target Spack package name and which Spack repo is used.  Conduit's source repo serves as an example for Uberenv and Spack configuration files, etc:
@@ -72,6 +72,9 @@ https://github.com/LLNL/conduit/tree/master/scripts/uberenv
 
 Command Line Options 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Build configuration
+-------------------
 
 ``uberenv.py`` has a few options that allow you to control how dependencies are built:
 
@@ -86,16 +89,17 @@ Command Line Options
   -k                   Ignore SSL Errors                              **False**
   --install            Fully install target, not just dependencies    **False**
   --run_tests          Invoke tests during build and against install  **False** 
+  --project-json       File for project specific settings             ``project.json``
  ==================== ============================================== ================================================
 
 The ``-k`` option exists for sites where SSL certificate interception undermines fetching
-from github and https hosted source tarballs. When enabled, ``uberenv.py`` clones spack using:
+from github and https hosted source tarballs. When enabled, ``uberenv.py`` clones Spack using:
 
 .. code:: bash
 
     git -c http.sslVerify=false clone https://github.com/llnl/spack.git
 
-And passes ``-k`` to any spack commands that may fetch via https.
+And passes ``-k`` to any Spack commands that may fetch via https.
 
 
 Default invocation on Linux:
@@ -145,6 +149,37 @@ destination directory. It then uses Spack to build and install the target packag
 ``spack/opt/spack/``. Finally, the target package generates a host-config file ``{hostname}.cmake``, which is 
 copied to destination directory. This file specifies the compiler settings and paths to all of the dependencies.
 
+Project configuration
+---------------------
+
+Part of the configuration can also be addressed using a json file. By default, it is named ``project.json`` and some settings can be overridden on command line:
+
+ ==================== ======================= ================================================ =======================================
+  Setting              Option                  Description                                      Default
+ ==================== ======================= ================================================ =======================================
+  package_name         --package-name          Spack package name                               **None**
+  package_version      **None**                Spack package version                            **None**
+  package_final_phase  --package-final-phase   Controls after which phase Spack should stop     **None**
+  package_source_dir   --package-source-dir    Controls the source directory Spack should use   **None**
+  spack_url            **None**                Url where to download Spack                      ``https://github.com/spack/spack.git``
+  spack_commit         **None**                Spack commit to checkout                         **None**
+  spack_activate       **None**                Spack packages to activate                       **None**
+ ==================== ======================= ================================================ =======================================
+
+
+Optimization
+------------
+
+``uberenv.py`` also features options to optimize the installation
+
+ ==================== ============================================== ================================================
+  Option               Description                                     Default
+ ==================== ============================================== ================================================
+  --mirror             Location of a Spack mirror                     **None**
+  --create-mirror      Creates a Spack mirror at specified location   **None**
+  --upstream           Location of a Spack upstream                   **None**
+ ==================== ============================================== ================================================
+
 
 Project Settings 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -153,6 +188,6 @@ A few notes on using ``uberenv.py`` in a new project:
 
 * For an example of how to craft a ``project.json`` file a target project, see: `Conduit's project.json file <https://github.com/LLNL/conduit/tree/master/scripts/uberenv/project.json>`_
 
-* ``uberenv.py`` hot copies ``packages`` to the cloned spack install, this allows you to easily version control any Spack package overrides necessary
+* ``uberenv.py`` hot copies ``packages`` to the cloned Spack install, this allows you to easily version control any Spack package overrides necessary
 
 

--- a/uberenv.py
+++ b/uberenv.py
@@ -130,20 +130,20 @@ def parse_args():
                       default=None,
                       help="dir with spack settings files (compilers.yaml, packages.yaml, etc)")
 
-    # overrides package name
-    parser.add_option("--pkg-name",
+    # overrides package_name
+    parser.add_option("--package-name",
                       dest="package_name",
                       default=None,
                       help="override the default package name")
 
     # controls after which package phase spack should stop
-    parser.add_option("--pkg-final-phase",
+    parser.add_option("--package-final-phase",
                       dest="package_final_phase",
                       default=None,
                       help="override the default phase after which spack should stop")
 
     # controls source_dir spack should use to build the package
-    parser.add_option("--pkg-src-dir",
+    parser.add_option("--package-source-dir",
                       dest="package_source_dir",
                       default=None,
                       help="override the default source dir spack should use")

--- a/uberenv.py
+++ b/uberenv.py
@@ -239,6 +239,25 @@ class UberEnv():
     def setup_paths_and_dirs(self):
         self.uberenv_path = os.path.dirname(os.path.realpath(__file__))
 
+    def set_from_args_or_json(self,setting):
+        try:
+            setting_value = self.project_opts[setting]
+        except (KeyError):
+            print("ERROR: {} must at least be defined in project.json".format(setting))
+            raise
+        else:
+            if self.opts[setting]:
+                setting_value = self.opts[setting]
+        return setting_value
+
+    def set_from_json(self,setting):
+        try:
+            setting_value = self.project_opts[setting]
+        except (KeyError):
+            print("ERROR: {} must at least be defined in project.json".format(setting))
+            raise
+        return setting_value
+
     def detect_platform(self):
         # find supported sets of compilers.yaml, packages,yaml
         res = None
@@ -256,17 +275,10 @@ class SpackEnv(UberEnv):
     def __init__(self, opts, extra_opts):
         UberEnv.__init__(self,opts,extra_opts)
 
-        if opts["package_name"]:
-            self.pkg_name = opts["package_name"]
-        else:
-            self.pkg_name = self.project_opts["package_name"]
-
-        self.pkg_version = self.project_opts["package_version"]
-
-        if opts["package_final_phase"]:
-            self.pkg_final_phase = opts["package_final_phase"]
-        else:
-            self.pkg_final_phase = self.project_opts["package_final_phase"]
+        self.pkg_name = self.set_from_args_or_json("package_name")
+        self.pkg_version = self.set_from_json("package_version")
+        self.pkg_final_phase = self.set_from_args_or_json("package_final_phase")
+        self.pkg_src_dir = self.set_from_args_or_json("package_source_dir")
 
         # Some additional setup for macos
         if is_darwin():
@@ -311,11 +323,6 @@ class SpackEnv(UberEnv):
 
         if os.path.isdir(self.dest_spack):
             print("[info: destination '{}' already exists]".format(self.dest_spack))
-
-        if self.opts["package_source_dir"]:
-            self.pkg_src_dir = self.opts["package_source_dir"]
-        else:
-            self.pkg_src_dir = self.project_opts["package_source_dir"]
 
         self.pkg_src_dir = os.path.join(self.uberenv_path,self.pkg_src_dir)
         if not os.path.isdir(self.pkg_src_dir):
@@ -459,14 +466,7 @@ class SpackEnv(UberEnv):
             install_cmd += "-k "
         install_cmd += "dev-build -d {} ".format(self.pkg_src_dir)
         if not self.opts["install"]:
-            try:
-                if self.pkg_final_phase:
-                    install_cmd += "-u {} ".format(self.pkg_final_phase)
-                else:
-                    raise ValueError("package_final_phase cannot be empty.")
-            except (KeyError, ValueError) as e:
-                print("ERROR: package_final_phase must be defined in project.json")
-                raise
+            install_cmd += "-u {} ".format(self.pkg_final_phase)
         if self.opts["run_tests"]:
             install_cmd += "--test=root "
         install_cmd += self.pkg_name + self.opts["spec"]

--- a/uberenv.py
+++ b/uberenv.py
@@ -344,10 +344,10 @@ class SpackEnv(UberEnv):
 
 
     def disable_spack_config_scopes(self,spack_dir):
-        # disables all config scopes except "default", which we will
+        # disables all config scopes except "defaults", which we will
         # force our settings into
         spack_lib_config = pjoin(spack_dir,"lib","spack","spack","config.py")
-        print("[disabling config scope (except default) in: {}]".format(spack_lib_config))
+        print("[disabling config scope (except defaults) in: {}]".format(spack_lib_config))
         cfg_script = open(spack_lib_config).read()
         for cfg_scope_stmt in ["('system', os.path.join(spack.paths.system_etc_path, 'spack')),",
                             "('site', os.path.join(spack.paths.etc_path, 'spack')),",
@@ -363,11 +363,11 @@ class SpackEnv(UberEnv):
         cfg_dir = self.config_dir()
         spack_dir = self.dest_spack
 
-        # force spack to use only default config scope
+        # force spack to use only "defaults" config scope
         self.disable_spack_config_scopes(spack_dir)
         spack_etc_defaults_dir = pjoin(spack_dir,"etc","spack","defaults")
 
-        # copy in default config.yaml
+        # copy in "defaults" config.yaml
         config_yaml = os.path.abspath(pjoin(self.uberenv_path,"spack_configs","config.yaml"))
         sexe("cp {} {}/".format(config_yaml, spack_etc_defaults_dir ), echo=True)
 
@@ -500,7 +500,7 @@ class SpackEnv(UberEnv):
 
     def find_spack_mirror(self, mirror_name):
         """
-        Returns the path of a site scoped spack mirror with the
+        Returns the path of a defaults scoped spack mirror with the
         given name, or None if no mirror exists.
         """
         rv, res = sexe("spack/bin/spack mirror list", ret_output=True)
@@ -528,18 +528,18 @@ class SpackEnv(UberEnv):
             # Note: In this case, spack says it removes the mirror, but we still
             # get errors when we try to add a new one, sounds like a bug
             #
-            sexe("spack/bin/spack mirror remove --scope=site {} ".format(mirror_name),
+            sexe("spack/bin/spack mirror remove --scope=defaults {} ".format(mirror_name),
                 echo=True)
             existing_mirror_path = None
         if not existing_mirror_path:
             # Add if not already there
-            sexe("spack/bin/spack mirror add --scope=site {} {}".format(
+            sexe("spack/bin/spack mirror add --scope=defaults {} {}".format(
                     mirror_name, mirror_path), echo=True)
             print("[using mirror {}]".format(mirror_path))
 
     def find_spack_upstream(self, upstream_name):
         """
-        Returns the path of a site scoped spack upstream with the
+        Returns the path of a defaults scoped spack upstream with the
         given name, or None if no upstream exists.
         """
         upstream_path = None

--- a/uberenv.py
+++ b/uberenv.py
@@ -264,9 +264,9 @@ class SpackEnv(UberEnv):
         self.pkg_version = self.project_opts["package_version"]
 
         if opts["package_final_phase"]:
-            self.pkg_stop_phase = opts["package_final_phase"]
+            self.pkg_final_phase = opts["package_final_phase"]
         else:
-            self.pkg_stop_phase = self.project_opts["package_final_phase"]
+            self.pkg_final_phase = self.project_opts["package_final_phase"]
 
         # Some additional setup for macos
         if is_darwin():
@@ -460,12 +460,12 @@ class SpackEnv(UberEnv):
         install_cmd += "dev-build -d {} ".format(self.pkg_src_dir)
         if not self.opts["install"]:
             try:
-                if self.pkg_stop_phase:
-                    install_cmd += "-u {} ".format(self.pkg_stop_phase)
+                if self.pkg_final_phase:
+                    install_cmd += "-u {} ".format(self.pkg_final_phase)
                 else:
-                    raise ValueError("package_stop_phase cannot be empty.")
+                    raise ValueError("package_final_phase cannot be empty.")
             except (KeyError, ValueError) as e:
-                print("ERROR: hostconfig_phase must be defined in project.json")
+                print("ERROR: package_final_phase must be defined in project.json")
                 raise
         if self.opts["run_tests"]:
             install_cmd += "--test=root "

--- a/uberenv.py
+++ b/uberenv.py
@@ -221,12 +221,13 @@ class UberEnv():
         self.pkg_name = self.project_opts["package_name"]
         self.pkg_version = self.project_opts["package_version"]
         self.pkg_stop_phase = self.project_opts["package_stop_phase"]
-        script_dir = os.path.dirname(os.path.realpath(__file__))
-        self.source_dir = os.path.join(script_dir,self.project_opts["source_dir"])
 
     def setup_paths_and_dirs(self):
-        self.uberenv_path = os.path.split(os.path.abspath(__file__))[0]
-
+        self.uberenv_path = os.path.dirname(os.path.realpath(__file__))
+        self.source_dir = os.path.join(self.uberenv_path,self.project_opts["source_dir"])
+        if not os.path.isdir(self.source_dir):
+            print("[ERROR: source_dir '{}'  exists]".format(self.source_dir))
+            sys.exit(-1)
 
     def detect_platform(self):
         # find supported sets of compilers.yaml, packages,yaml

--- a/uberenv.py
+++ b/uberenv.py
@@ -425,7 +425,14 @@ class SpackEnv(UberEnv):
             install_cmd += "-k "
         install_cmd += "dev-build -d {} ".format(self.source_dir)
         if not self.opts["install"]:
-            install_cmd += "-u {} ".format(self.pkg_stop_phase)
+            try:
+                if self.pkg_stop_phase:
+                    install_cmd += "-u {} ".format(self.pkg_stop_phase)
+                else:
+                    raise ValueError("package_stop_phase cannot be empty.")
+            except (KeyError, ValueError) as e:
+                print("ERROR: hostconfig_phase must be defined in project.json")
+                raise
         if self.opts["run_tests"]:
             install_cmd += "--test=root "
         install_cmd += self.pkg_name + self.opts["spec"]

--- a/uberenv.py
+++ b/uberenv.py
@@ -286,9 +286,9 @@ class SpackEnv(UberEnv):
         if os.path.isdir(self.dest_spack):
             print("[info: destination '{}' already exists]".format(self.dest_spack))
 
-        self.source_dir = os.path.join(self.uberenv_path,self.project_opts["source_dir"])
-        if not os.path.isdir(self.source_dir):
-            print("[ERROR: source_dir '{}' does not exist]".format(self.source_dir))
+        self.pkg_src_dir = os.path.join(self.uberenv_path,self.project_opts["package_source_dir"])
+        if not os.path.isdir(self.pkg_src_dir):
+            print("[ERROR: package_source_dir '{}' does not exist]".format(self.pkg_src_dir))
             sys.exit(-1)
 
 
@@ -427,7 +427,7 @@ class SpackEnv(UberEnv):
         install_cmd = "spack/bin/spack "
         if self.opts["ignore_ssl_errors"]:
             install_cmd += "-k "
-        install_cmd += "dev-build -d {} ".format(self.source_dir)
+        install_cmd += "dev-build -d {} ".format(self.pkg_src_dir)
         if not self.opts["install"]:
             try:
                 if self.pkg_stop_phase:

--- a/uberenv.py
+++ b/uberenv.py
@@ -276,10 +276,9 @@ class SpackEnv(UberEnv):
     def find_spack_pkg_path(self,pkg_name):
         r,rout = sexe("spack/bin/spack find -p " + pkg_name,ret_output = True)
         for l in rout.split("\n"):
-            lstrip = l.strip()
-            if not lstrip == "" and \
-               not lstrip.startswith("==>") and  \
-               not lstrip.startswith("--"):
+            # TODO: at least print a warning when several choices exist. This will
+            # pick the first in the list.
+            if l.startswith(pkg_name):
                    return {"name": pkg_name, "path": l.split()[-1]}
         print("[ERROR: failed to find package named '{}']".format(pkg_name))
         sys.exit(-1)

--- a/uberenv.py
+++ b/uberenv.py
@@ -90,7 +90,8 @@ def parse_args():
                       action="store_true",
                       dest="install",
                       default=False,
-                      help="Install `package_name` instead of `uberenv_package_name`.")
+                      help="Install `package_name`, not just its dependencies.")
+
     # where to install
     parser.add_option("--prefix",
                       dest="prefix",
@@ -297,7 +298,7 @@ class SpackEnv(UberEnv):
 
             os.chdir(self.dest_dir)
 
-            clone_opts = ("-c http.sslVerify=false " 
+            clone_opts = ("-c http.sslVerify=false "
                           if self.opts["ignore_ssl_errors"] else "")
 
             spack_branch = self.project_opts.get("spack_branch", "develop")
@@ -436,7 +437,7 @@ class SpackEnv(UberEnv):
         if self.opts["install"] and "+python" in full_spec:
             activate_cmd = "spack/bin/spack activate " + self.pkg_name
             sexe(activate_cmd, echo=True)
-        # if user opt'd for an install, we want to symlink the final ascent
+        # if user opt'd for an install, we want to symlink the final
         # install to an easy place:
         if self.opts["install"]:
             pkg_path = self.find_spack_pkg_path(self.pkg_name)

--- a/uberenv.py
+++ b/uberenv.py
@@ -218,16 +218,8 @@ class UberEnv():
         print("[uberenv project settings: {}]".format(str(self.project_opts)))
         print("[uberenv options: {}]".format(str(self.opts)))
 
-        self.pkg_name = self.project_opts["package_name"]
-        self.pkg_version = self.project_opts["package_version"]
-        self.pkg_stop_phase = self.project_opts["package_stop_phase"]
-
     def setup_paths_and_dirs(self):
         self.uberenv_path = os.path.dirname(os.path.realpath(__file__))
-        self.source_dir = os.path.join(self.uberenv_path,self.project_opts["source_dir"])
-        if not os.path.isdir(self.source_dir):
-            print("[ERROR: source_dir '{}'  exists]".format(self.source_dir))
-            sys.exit(-1)
 
     def detect_platform(self):
         # find supported sets of compilers.yaml, packages,yaml
@@ -246,6 +238,10 @@ class SpackEnv(UberEnv):
     def __init__(self, opts, extra_opts):
         UberEnv.__init__(self,opts,extra_opts)
 
+        self.pkg_name = self.project_opts["package_name"]
+        self.pkg_version = self.project_opts["package_version"]
+        self.pkg_stop_phase = self.project_opts["package_stop_phase"]
+
         # Some additional setup for macos
         if is_darwin():
             if opts["macos_sdk_env_setup"]:
@@ -260,10 +256,13 @@ class SpackEnv(UberEnv):
                 opts["spec"] = "%clang"
             else:
                 opts["spec"] = "%gcc"
+            self.opts["spec"] = "@{}{}".format(self.pkg_version,opts["spec"])
+        elif not opts["spec"].startswith("@"):
+            self.opts["spec"] = "@{}{}".format(self.pkg_version,opts["spec"])
+        else:
+            self.opts["spec"] = "{}".format(opts["spec"])
 
-        opts["spec"] = "@{}{}".format(self.pkg_version,opts["spec"])
-
-        print("[spack spec: {}]".format(opts["spec"]))
+        print("[spack spec: {}]".format(self.opts["spec"]))
 
     def setup_paths_and_dirs(self):
         # get the current working path, and the glob used to identify the
@@ -286,6 +285,11 @@ class SpackEnv(UberEnv):
 
         if os.path.isdir(self.dest_spack):
             print("[info: destination '{}' already exists]".format(self.dest_spack))
+
+        self.source_dir = os.path.join(self.uberenv_path,self.project_opts["source_dir"])
+        if not os.path.isdir(self.source_dir):
+            print("[ERROR: source_dir '{}' does not exist]".format(self.source_dir))
+            sys.exit(-1)
 
 
     def find_spack_pkg_path(self,pkg_name):

--- a/uberenv.py
+++ b/uberenv.py
@@ -220,6 +220,9 @@ class UberEnv():
 
         self.pkg_name = self.project_opts["package_name"]
         self.pkg_version = self.project_opts["package_version"]
+        self.pkg_stop_phase = self.project_opts["package_stop_phase"]
+        script_dir = os.path.dirname(os.path.realpath(__file__))
+        self.source_dir = os.path.join(script_dir,self.project_opts["source_dir"])
 
     def setup_paths_and_dirs(self):
         self.uberenv_path = os.path.split(os.path.abspath(__file__))[0]
@@ -419,7 +422,9 @@ class SpackEnv(UberEnv):
         install_cmd = "spack/bin/spack "
         if self.opts["ignore_ssl_errors"]:
             install_cmd += "-k "
-        install_cmd += "install "
+        install_cmd += "dev-build -d {} ".format(self.source_dir)
+        if not self.opts["install"]:
+            install_cmd += "-u {} ".format(self.pkg_stop_phase)
         if self.opts["run_tests"]:
             install_cmd += "--test=root "
         install_cmd += self.pkg_name + self.opts["spec"]

--- a/uberenv.py
+++ b/uberenv.py
@@ -493,7 +493,7 @@ class SpackEnv(UberEnv):
                                                                     self.pkg_name)
         return sexe(mirror_cmd, echo=True)
 
-    def find_spack_mirror(self, spack_dir, mirror_name):
+    def find_spack_mirror(self, mirror_name):
         """
         Returns the path of a site scoped spack mirror with the
         given name, or None if no mirror exists.
@@ -511,10 +511,9 @@ class SpackEnv(UberEnv):
         """
         Configures spack to use mirror at a given path.
         """
-        spack_dir = self.dest_spack
         mirror_name = self.pkg_name
         mirror_path = self.get_mirror_path()
-        existing_mirror_path = self.find_spack_mirror(spack_dir, mirror_name)
+        existing_mirror_path = self.find_spack_mirror(mirror_name)
 
         if existing_mirror_path and mirror_path != existing_mirror_path:
             # Existing mirror has different URL, error out

--- a/uberenv.py
+++ b/uberenv.py
@@ -207,11 +207,8 @@ class UberEnv():
         print("[uberenv project settings: {}]".format(str(self.project_opts)))
         print("[uberenv options: {}]".format(str(self.opts)))
 
-        # setup main package name
-        if opts["install"]:
-            self.pkg_name = self.project_opts["package_name"]
-        else:
-            self.pkg_name = self.project_opts["uberenv_package_name"]
+        self.pkg_name = self.project_opts["package_name"]
+        self.pkg_version = self.project_opts["package_version"]
 
     def setup_paths_and_dirs(self):
         self.uberenv_path = os.path.split(os.path.abspath(__file__))[0]
@@ -248,6 +245,9 @@ class SpackEnv(UberEnv):
                 opts["spec"] = "%clang"
             else:
                 opts["spec"] = "%gcc"
+
+        opts["spec"] = "@{}{}".format(self.pkg_version,opts["spec"])
+
         print("[spack spec: {}]".format(opts["spec"]))
 
     def setup_paths_and_dirs(self):

--- a/uberenv.py
+++ b/uberenv.py
@@ -130,6 +130,24 @@ def parse_args():
                       default=None,
                       help="dir with spack settings files (compilers.yaml, packages.yaml, etc)")
 
+    # overrides package name
+    parser.add_option("--pkg-name",
+                      dest="package_name",
+                      default=None,
+                      help="override the default package name")
+
+    # controls after which package phase spack should stop
+    parser.add_option("--pkg-final-phase",
+                      dest="package_final_phase",
+                      default=None,
+                      help="override the default phase after which spack should stop")
+
+    # controls source_dir spack should use to build the package
+    parser.add_option("--pkg-src-dir",
+                      dest="package_source_dir",
+                      default=None,
+                      help="override the default source dir spack should use")
+
     # a file that holds settings for a specific project
     # using uberenv.py
     parser.add_option("--project-json",
@@ -238,9 +256,17 @@ class SpackEnv(UberEnv):
     def __init__(self, opts, extra_opts):
         UberEnv.__init__(self,opts,extra_opts)
 
-        self.pkg_name = self.project_opts["package_name"]
+        if opts["package_name"]:
+            self.pkg_name = opts["package_name"]
+        else:
+            self.pkg_name = self.project_opts["package_name"]
+
         self.pkg_version = self.project_opts["package_version"]
-        self.pkg_stop_phase = self.project_opts["package_stop_phase"]
+
+        if opts["package_final_phase"]:
+            self.pkg_stop_phase = opts["package_final_phase"]
+        else:
+            self.pkg_stop_phase = self.project_opts["package_final_phase"]
 
         # Some additional setup for macos
         if is_darwin():
@@ -286,7 +312,12 @@ class SpackEnv(UberEnv):
         if os.path.isdir(self.dest_spack):
             print("[info: destination '{}' already exists]".format(self.dest_spack))
 
-        self.pkg_src_dir = os.path.join(self.uberenv_path,self.project_opts["package_source_dir"])
+        if self.opts["package_source_dir"]:
+            self.pkg_src_dir = self.opts["package_source_dir"]
+        else:
+            self.pkg_src_dir = self.project_opts["package_source_dir"]
+
+        self.pkg_src_dir = os.path.join(self.uberenv_path,self.pkg_src_dir)
         if not os.path.isdir(self.pkg_src_dir):
             print("[ERROR: package_source_dir '{}' does not exist]".format(self.pkg_src_dir))
             sys.exit(-1)
@@ -360,7 +391,6 @@ class SpackEnv(UberEnv):
             cfg_script = cfg_script.replace(cfg_scope_stmt,
                                             "#DISABLED BY UBERENV: " + cfg_scope_stmt)
         open(spack_lib_config,"w").write(cfg_script)
-
 
 
     def patch(self):


### PR DESCRIPTION
## Summary
This branch introduces the latest changes tested with Serac.
Changelog:
- no fake package required, uberenv relies on `spack dev-build` command which can stop a package install _after_ a given phase (-u option for "until").
- allowing the definition of an upstream instance of spack. (closes #10)

## Details
Although the workflow remains unchanged, some changes are necessary in project.json:
The package related variables, package_name, package_version, package_source_dir and package_final_phase are mandatory to preserve the workflow.
`uberenv` installs only the dependencies stoping after package_final_phase.
`uberenv --install` performs the full install of the package, defaulting to the specified package_version.

Those four options can be overridden respectively with --package-name, --spec, --package-source-dir and --package-final-phase.

## Intended usage
The goal is to allow to stop the project package right after the generation of the host-config file. The prerequisite is to define this step in a separate phase of the package.

### Development context
This simplifies the management of host config files and installation of libraries.

### CI/CD context
These changes also allow to build a CI process which will build the dependencies with Spack (or use the dependencies installed in the upstream Spack instance), and then build and test the project using the local sources. _This part of the workflow is tested in Serac_.
Eventually, the delivery pipeline can test the full installation using the embedded Spack package, and on success deploy both the code and the spack package. _This part is still to be tested on a project_.
Spack being part of the process, this should improve the reliability of its usage by spotting issues as soon as possible in the workflow.