### PR TITLE
Fixes, Improvements and CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -52,3 +52,11 @@ trigger-conduit:
     project: radiuss/conduit
     branch: feature/uberenv_ci
     strategy: depend
+
+trigger-serac:
+  variables:
+    UPDATE_UBERENV: $CI_COMMIT_REF_NAME
+  trigger:
+    project: bernede1/serac
+    branch: feature/up-uber
+    strategy: depend

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,54 @@
+###############################################################################
+# Copyright (c) 2014-2020, Lawrence Livermore National Security, LLC.
+#
+# Produced at the Lawrence Livermore National Laboratory
+#
+# LLNL-CODE-666778
+#
+# All rights reserved.
+#
+# This file is part of Conduit.
+#
+# For details, see https://lc.llnl.gov/conduit/.
+#
+# Please also read conduit/LICENSE
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the disclaimer below.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the disclaimer (as noted below) in the
+#   documentation and/or other materials provided with the distribution.
+#
+# * Neither the name of the LLNS/LLNL nor the names of its contributors may
+#   be used to endorse or promote products derived from this software without
+#   specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL LAWRENCE LIVERMORE NATIONAL SECURITY,
+# LLC, THE U.S. DEPARTMENT OF ENERGY OR CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+###############################################################################
+
+# Triggers Conduit pipeline asking for uberenv update
+# UPDATE_UBERENV variable, when set, will tell conduit to use the value as
+# a reference to the uberenv env revision to checkout on github.
+trigger-conduit:
+  variables:
+    UPDATE_UBERENV: $CI_COMMIT_REF_NAME
+  trigger:
+    project: radiuss/conduit
+    branch: feature/uberenv_ci
+    strategy: depend

--- a/uberenv.py
+++ b/uberenv.py
@@ -469,16 +469,16 @@ class SpackEnv(UberEnv):
                         res = sexe(unist_cmd, echo=True)
 
     def show_info(self):
-        spec_cmd = "spack/bin/spack spec -Il " + self.pkg_name + self.opts["spec"]
+        spec_cmd = "spack/bin/spack spec -IL " + self.pkg_name + self.opts["spec"]
 
         res, out = sexe(spec_cmd, ret_output=True, echo=True)
         print(out)
 
         for line in out.split("\n"):
-            if re.match(rf'^(\[\+\]| - )  [a-z0-9]{{32}}  {self.pkg_name}', line):
+            if re.match(r"^(\[\+\]| - )  [a-z0-9]{32}  " + re.escape(self.pkg_name), line):
                 self.spec_hash = line.split("  ")[1]
                 if line.startswith("[+]"):
-                    pkg_path = self.find_spack_pkg_path_form_hash(self.pkg_name,self.pkg_hash)
+                    pkg_path = self.find_spack_pkg_path_form_hash(self.pkg_name,self.spec_hash)
                     install_path = pkg_path["path"]
                     if os.path.isdir(install_path):
                         print("[Warning: {} {} has already been install in {}]".format(self.pkg_name, self.opts["spec"],install_path))
@@ -504,10 +504,10 @@ class SpackEnv(UberEnv):
             install_cmd += self.pkg_name + self.opts["spec"]
             res, out = sexe(install_cmd, ret_output=True, echo=True)
 
+        full_spec = self.read_spack_full_spec(self.pkg_name,self.opts["spec"])
         if "spack_activate" in self.project_opts:
             print("[activating dependent packages]")
             # get the full spack spec for our project
-            full_spec = self.read_spack_full_spec(self.pkg_name,self.opts["spec"])
             pkg_names = self.project_opts["spack_activate"].keys()
             for pkg_name in pkg_names:
                 pkg_spec_requirements = self.project_opts["spack_activate"][pkg_name]

--- a/uberenv.py
+++ b/uberenv.py
@@ -531,12 +531,12 @@ class SpackEnv(UberEnv):
         # note: this assumes package extends python when +python
         # this may fail general cases
         if self.opts["install"] and "+python" in full_spec:
-            activate_cmd = "spack/bin/spack activate " + self.pkg_name + self.opts["spec"]
+            activate_cmd = "spack/bin/spack activate /" + self.spec_hash
             sexe(activate_cmd, echo=True)
         # if user opt'd for an install, we want to symlink the final
         # install to an easy place:
         if self.opts["install"] or self.use_install:
-            pkg_path = self.find_spack_pkg_path(self.pkg_name,self.opts["spec"])
+            pkg_path = self.find_spack_pkg_path_from_hash(self.pkg_name, self.spec_hash)
             if self.pkg_name != pkg_path["name"]:
                 print("[ERROR: Could not find install of {}]".format(self.pkg_name))
                 return -1

--- a/uberenv.py
+++ b/uberenv.py
@@ -341,7 +341,7 @@ class SpackEnv(UberEnv):
         print("[ERROR: failed to find package named '{}']".format(pkg_name))
         sys.exit(-1)
 
-    def find_spack_pkg_path(self,pkg_name,spec):
+    def find_spack_pkg_path(self, pkg_name, spec = ""):
         r,rout = sexe("spack/bin/spack find -p " + pkg_name + spec,ret_output = True)
         for l in rout.split("\n"):
             # TODO: at least print a warning when several choices exist. This will
@@ -522,12 +522,12 @@ class SpackEnv(UberEnv):
         # note: this assumes package extends python when +python
         # this may fail general cases
         if self.opts["install"] and "+python" in full_spec:
-            activate_cmd = "spack/bin/spack activate " + self.pkg_name
+            activate_cmd = "spack/bin/spack activate " + self.pkg_name + self.opts["spec"]
             sexe(activate_cmd, echo=True)
         # if user opt'd for an install, we want to symlink the final
         # install to an easy place:
         if self.opts["install"] or "use_install" in self.opts:
-            pkg_path = self.find_spack_pkg_path(self.pkg_name)
+            pkg_path = self.find_spack_pkg_path(self.pkg_name,self.opts["spec"])
             if self.pkg_name != pkg_path["name"]:
                 print("[ERROR: Could not find install of {}]".format(self.pkg_name))
                 return -1

--- a/uberenv.py
+++ b/uberenv.py
@@ -487,6 +487,8 @@ class SpackEnv(UberEnv):
                 if line.startswith("[+]"):
                     pkg_path = self.find_spack_pkg_path_from_hash(self.pkg_name,self.spec_hash)
                     install_path = pkg_path["path"]
+                    # testing that the path exists is mandatory until Spack team fixes
+                    # https://github.com/spack/spack/issues/16329
                     if os.path.isdir(install_path):
                         print("[Warning: {} {} has already been installed in {}]".format(self.pkg_name, self.opts["spec"],install_path))
                         print("[Warning: Uberenv will proceed using this directory]".format(self.pkg_name))


### PR DESCRIPTION
Fixes some undesired behavior introduced lately (see https://github.com/LLNL/conduit/pull/502).

Also introduce some robustness improvements:
 - Check if a spec is already installed.
 - Ability to use the spec hash to accurately retrieve information (e.g. spack install path).

Add CI triggering Gitlab CI pipeline in Conduit and Serac.

Recent change:
 - Roll back of sexe() implementation after feedback. 