### PR TITLE
Adds Vcpkg as Uberenv's package manager on Windows

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2014-2018, Lawrence Livermore National Security, LLC.
+Copyright (c) 2014-2020, Lawrence Livermore National Security, LLC.
 
 Produced at the Lawrence Livermore National Laboratory
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
 # uberenv
-Automates using Spack (https://www.spack.io/) to build and deploy software.
+Automates using a package manager to build and deploy software.
 
-Uberenv is a short python script that helps automate using Spack to build
-third-party dependencies for development and to deploy Spack packages. 
+Uberenv is a short python script that helps automate building
+third-party dependencies for development and deployment. 
 
-Uberenv was released as part of the Conduit (https://github.com/LLNL/conduit/). It is included in-source in several projects, this repo is used to hold the latest reference version.
+Uberenv use Spack (https://www.spack.io/) on Unix-based systems (e.g. Linux and macOS)
+and Vcpkg (https://github.com/microsoft/vcpkg) on Windows systems.
+
+Uberenv was released as part of the Conduit project (https://github.com/LLNL/conduit/). 
+It is included in-source in several projects, this repo is used to hold the latest reference version.
 
 For more details, see Uberenv's documention:
 

--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -1,5 +1,5 @@
 .. ############################################################################
-.. # Copyright (c) 2014-2018, Lawrence Livermore National Security, LLC.
+.. # Copyright (c) 2014-2020, Lawrence Livermore National Security, LLC.
 .. #
 .. # Produced at the Lawrence Livermore National Laboratory
 .. #
@@ -47,10 +47,12 @@
 Uberenv
 ~~~~~~~~~~~~~~~
 
-**Uberenv** automates using `Spack <ttp://www.spack.io>`_ to build and deploy software.
+**Uberenv** automates using a package manager to build and deploy software.
+It uses `Spack <http://www.spack.io>`_ on Unix-based systems (e.g. Linux and macOS)
+and `Vcpkg <https://github.com/microsoft/vcpkg>`_ on Windows systems.
 
-Many projects leverage `Spack <ttp://www.spack.io>`_ to help build the software dependencies needed to develop and deploy their projects on HPC systems. Uberenv is a python script that helps automate using Spack to build
-third-party dependencies for development and to deploy Spack packages.
+Many projects leverage package managers, like Spack and Vcpkg to help build the software dependencies needed to develop and deploy their projects on HPC systems. Uberenv is a python script that helps automate usage of a package manager to build
+third-party dependencies for development and deployment.
 
 Uberenv was released as part of Conduit (https://github.com/LLNL/conduit/). It is included in-source in several projects. The
 https://github.com/llnl/uberenv/ repo is used to hold the latest reference version of Uberenv.
@@ -59,15 +61,17 @@ https://github.com/llnl/uberenv/ repo is used to hold the latest reference versi
 uberenv.py
 ~~~~~~~~~~~~~~~~~~~~~
 
-``uberenv.py`` is a single file python script that automates fetching Spack, building and installing third party dependencies, and can optionally install packages as well.  To automate the full install process, ``uberenv.py`` uses a target Spack package along with extra settings such as Spack compiler and external third party package details for common HPC platforms.
+``uberenv.py`` is a single file python script that automates fetching Spack or Vcpkg, building and installing third party dependencies, and can optionally install packages as well.  To automate the full install process, ``uberenv.py`` uses a target Spack or Vcpkg package along with extra settings such as compilers and external third party package details for common HPC platforms.
 
-``uberenv.py`` is included directly in a project's source code repo in the folder: ``scripts/uberenv/``
-This folder is also used to store extra Spack and Uberenv configuration files unique to the target project. ``uberenv.py`` uses a ``project.json`` file to specify project details, including the target Spack package name and which Spack repo is used.  Conduit's source repo serves as an example for Uberenv and Spack configuration files, etc:
+``uberenv.py`` is typically included directly in a project's source code repo in the folder: ``scripts/uberenv/``
+This folder is also used to store extra configuration files unique to the target project. ``uberenv.py`` uses a ``project.json`` file to specify project details, including the target package name and the base branch or commit in the package manager.  
+
+Conduit's source repo serves as an example for Uberenv and Spack configuration files, etc:
 
 https://github.com/LLNL/conduit/tree/master/scripts/uberenv
 
 
-``uberenv.py`` is developed by LLNL in support of the `Ascent <http://github.com/alpine-dav/ascent/>`_, Axom, and `Conduit <https://github.com/llnl/conduit>`_  projects.
+``uberenv.py`` is developed by LLNL in support of the `Ascent <http://github.com/alpine-dav/ascent/>`_, `Axom <https://github.com/llnl/axom>`_, and `Conduit <https://github.com/llnl/conduit>`_  projects.
 
 
 Command Line Options
@@ -90,6 +94,7 @@ Build configuration
   ``--install``           Fully install target, not just dependencies    **False**
   ``--run_tests``         Invoke tests during build and against install  **False**
   ``--project-json``      File for project specific settings             ``project.json``
+  ``--triplet``           (vcpkg) Target architecture and linkage        ``x86-Windows``
  ======================= ============================================== ================================================
 
 The ``-k`` option exists for sites where SSL certificate interception undermines fetching
@@ -117,6 +122,14 @@ Default invocation on OSX:
                                       --spec %clang \
                                       --spack-config-dir scripts/uberenv/spack_configs/darwin/
 
+Default invocation on Windows:
+
+.. code:: bash
+
+    python scripts/uberenv/uberenv.py --prefix uberenv_libs \
+                                      --triplet x86-windows
+
+See `Vcpkg user docs <https://vcpkg.readthedocs.io/en/latest/users/triplets/>`_ for more information about triplets.
 
 Use the ``--install`` option to install the target package (not just its development dependencies):
 
@@ -162,10 +175,16 @@ Part of the configuration can also be addressed using a json file. By default, i
   package_version      **None**                   Spack package version                            **None**
   package_final_phase  ``--package-final-phase``  Controls after which phase Spack should stop     **None**
   package_source_dir   ``--package-source-dir``   Controls the source directory Spack should use   **None**
-  spack_url            **None**                   Url where to download Spack                      ``https://github.com/spack/spack.git``
+  spack_url            **None**                   Download url for Spack                          ``https://github.com/spack/spack.git``
+  spack_branch         **None**                   Spack branch to checkout                         ``develop``
   spack_commit         **None**                   Spack commit to checkout                         **None**
   spack_activate       **None**                   Spack packages to activate                       **None**
+  vcpkg_url            **None**                   Download url for Vcpkg                          ``https://github.com/microsoft/vcpkg``
+  vcpkg_branch         **None**                   Vcpkg branch to checkout                         ``master``
+  vcpkg_commit         **None**                   Vcpkg commit to checkout                         **None**
  ==================== ========================== ================================================ =======================================
+
+If a ``spack_commit`` is present, it supercedes the ``spack_branch`` option, and similarly for ``vcpkg_commit`` and ``vcpkg_branch``.
 
 
 Optimization
@@ -180,6 +199,9 @@ Optimization
   ``--create-mirror``  Creates a Spack mirror at specified location   **None**
   ``--upstream``       Location of a Spack upstream                   **None**
  ==================== ============================================== ================================================
+
+.. note::
+    These options are only currently available for spack.
 
 
 Project Settings

--- a/uberenv.py
+++ b/uberenv.py
@@ -1,7 +1,7 @@
 #!/bin/sh
 "exec" "python" "-u" "-B" "$0" "$@"
 ###############################################################################
-# Copyright (c) 2014-2019, Lawrence Livermore National Security, LLC.
+# Copyright (c) 2014-2020, Lawrence Livermore National Security, LLC.
 #
 # Produced at the Lawrence Livermore National Laboratory
 #
@@ -70,7 +70,7 @@ from os.path import join as pjoin
 def sexe(cmd,ret_output=False,echo = False):
     """ Helper for executing shell commands. """
     if echo:
-        print("[exe: {}]".format(cmd))
+        print("[exe: {0}]".format(cmd))
     if ret_output:
         p = subprocess.Popen(cmd,
                              shell=True,
@@ -205,7 +205,7 @@ def parse_args():
     if not opts["spack_config_dir"] is None:
         opts["spack_config_dir"] = os.path.abspath(opts["spack_config_dir"])
         if not os.path.isdir(opts["spack_config_dir"]):
-            print("[ERROR: invalid spack config dir: {} ]".format(opts["spack_config_dir"]))
+            print("[ERROR: invalid spack config dir: {0} ]".format(opts["spack_config_dir"]))
             sys.exit(-1)
     return opts, extras
 
@@ -233,8 +233,8 @@ class UberEnv():
 
         # load project settings
         self.project_opts = load_json_file(opts["project_json"])
-        print("[uberenv project settings: {}]".format(str(self.project_opts)))
-        print("[uberenv options: {}]".format(str(self.opts)))
+        print("[uberenv project settings: {0}]".format(str(self.project_opts)))
+        print("[uberenv options: {0}]".format(str(self.opts)))
 
     def setup_paths_and_dirs(self):
         self.uberenv_path = os.path.dirname(os.path.realpath(__file__))
@@ -243,7 +243,7 @@ class UberEnv():
         try:
             setting_value = self.project_opts[setting]
         except (KeyError):
-            print("ERROR: {} must at least be defined in project.json".format(setting))
+            print("ERROR: {0} must at least be defined in project.json".format(setting))
             raise
         else:
             if self.opts[setting]:
@@ -254,7 +254,7 @@ class UberEnv():
         try:
             setting_value = self.project_opts[setting]
         except (KeyError):
-            print("ERROR: {} must at least be defined in project.json".format(setting))
+            print("ERROR: {0} must at least be defined in project.json".format(setting))
             raise
         return setting_value
 
@@ -294,13 +294,13 @@ class SpackEnv(UberEnv):
                 opts["spec"] = "%clang"
             else:
                 opts["spec"] = "%gcc"
-            self.opts["spec"] = "@{}{}".format(self.pkg_version,opts["spec"])
+            self.opts["spec"] = "@{0}{1}".format(self.pkg_version,opts["spec"])
         elif not opts["spec"].startswith("@"):
-            self.opts["spec"] = "@{}{}".format(self.pkg_version,opts["spec"])
+            self.opts["spec"] = "@{0}{1}".format(self.pkg_version,opts["spec"])
         else:
-            self.opts["spec"] = "{}".format(opts["spec"])
+            self.opts["spec"] = "{0}".format(opts["spec"])
 
-        print("[spack spec: {}]".format(self.opts["spec"]))
+        print("[spack spec: {0}]".format(self.opts["spec"]))
 
     def setup_paths_and_dirs(self):
         # get the current working path, and the glob used to identify the
@@ -319,14 +319,14 @@ class SpackEnv(UberEnv):
         if not os.path.isdir(self.dest_dir):
             os.mkdir(self.dest_dir)
         else:
-            print("[info: destination '{}' already exists]".format(self.dest_dir))
+            print("[info: destination '{0}' already exists]".format(self.dest_dir))
 
         if os.path.isdir(self.dest_spack):
-            print("[info: destination '{}' already exists]".format(self.dest_spack))
+            print("[info: destination '{0}' already exists]".format(self.dest_spack))
 
         self.pkg_src_dir = os.path.join(self.uberenv_path,self.pkg_src_dir)
         if not os.path.isdir(self.pkg_src_dir):
-            print("[ERROR: package_source_dir '{}' does not exist]".format(self.pkg_src_dir))
+            print("[ERROR: package_source_dir '{0}' does not exist]".format(self.pkg_src_dir))
             sys.exit(-1)
 
 
@@ -337,7 +337,7 @@ class SpackEnv(UberEnv):
             # pick the first in the list.
             if l.startswith(pkg_name):
                    return {"name": pkg_name, "path": l.split()[-1]}
-        print("[ERROR: failed to find package named '{}']".format(pkg_name))
+        print("[ERROR: failed to find package named '{0}']".format(pkg_name))
         sys.exit(-1)
 
     def read_spack_full_spec(self,pkg_name,spec):
@@ -360,15 +360,15 @@ class SpackEnv(UberEnv):
             spack_branch = self.project_opts.get("spack_branch", "develop")
             spack_url = self.project_opts.get("spack_url", "https://github.com/spack/spack.git")
 
-            clone_cmd =  "git {} clone -b {} {}".format(clone_opts, spack_branch,spack_url)
+            clone_cmd =  "git {0} clone -b {1} {2}".format(clone_opts, spack_branch,spack_url)
             sexe(clone_cmd, echo=True)
 
             # optionally, check out a specific commit
             if "spack_commit" in self.project_opts:
                 sha1 = self.project_opts["spack_commit"]
-                print("[info: using spack commit {}]".format(sha1))
+                print("[info: using spack commit {0}]".format(sha1))
                 os.chdir(pjoin(self.dest_dir,"spack"))
-                sexe("git checkout {}".format(sha1),echo=True)
+                sexe("git checkout {0}".format(sha1),echo=True)
 
         if self.opts["spack_pull"]:
             # do a pull to make sure we have the latest
@@ -390,7 +390,7 @@ class SpackEnv(UberEnv):
         # disables all config scopes except "defaults", which we will
         # force our settings into
         spack_lib_config = pjoin(spack_dir,"lib","spack","spack","config.py")
-        print("[disabling config scope (except defaults) in: {}]".format(spack_lib_config))
+        print("[disabling config scope (except defaults) in: {0}]".format(spack_lib_config))
         cfg_script = open(spack_lib_config).read()
         for cfg_scope_stmt in ["('system', os.path.join(spack.paths.system_etc_path, 'spack')),",
                             "('site', os.path.join(spack.paths.etc_path, 'spack')),",
@@ -411,7 +411,7 @@ class SpackEnv(UberEnv):
 
         # copy in "defaults" config.yaml
         config_yaml = os.path.abspath(pjoin(self.uberenv_path,"spack_configs","config.yaml"))
-        sexe("cp {} {}/".format(config_yaml, spack_etc_defaults_dir ), echo=True)
+        sexe("cp {0} {1}/".format(config_yaml, spack_etc_defaults_dir ), echo=True)
 
         # copy in other settings per platform
         if not cfg_dir is None:
@@ -422,19 +422,19 @@ class SpackEnv(UberEnv):
             packages_yaml  = pjoin(cfg_dir,"packages.yaml")
 
             if os.path.isfile(config_yaml):
-                sexe("cp {} {}/".format(config_yaml , spack_etc_defaults_dir ), echo=True)
+                sexe("cp {0} {1}/".format(config_yaml , spack_etc_defaults_dir ), echo=True)
 
             if os.path.isfile(compilers_yaml):
-                sexe("cp {} {}/".format(compilers_yaml, spack_etc_defaults_dir ), echo=True)
+                sexe("cp {0} {1}/".format(compilers_yaml, spack_etc_defaults_dir ), echo=True)
 
             if os.path.isfile(packages_yaml):
-                sexe("cp {} {}/".format(packages_yaml, spack_etc_defaults_dir ), echo=True)
+                sexe("cp {0} {1}/".format(packages_yaml, spack_etc_defaults_dir ), echo=True)
         else:
             # let spack try to auto find compilers
             sexe("spack/bin/spack compiler find", echo=True)
         dest_spack_pkgs = pjoin(spack_dir,"var","spack","repos","builtin","packages")
         # hot-copy our packages into spack
-        sexe("cp -Rf {} {}".format(self.pkgs,dest_spack_pkgs))
+        sexe("cp -Rf {0} {1}".format(self.pkgs,dest_spack_pkgs))
 
 
     def clean_build(self):
@@ -465,7 +465,7 @@ class SpackEnv(UberEnv):
         if self.opts["ignore_ssl_errors"]:
             install_cmd += "-k "
         if not self.opts["install"]:
-            install_cmd += "dev-build -d {} -u {} ".format(self.pkg_src_dir,self.pkg_final_phase)
+            install_cmd += "dev-build -d {0} -u {1} ".format(self.pkg_src_dir,self.pkg_final_phase)
         else:
             install_cmd += "install "
             if self.opts["run_tests"]:
@@ -500,14 +500,14 @@ class SpackEnv(UberEnv):
         if self.opts["install"]:
             pkg_path = self.find_spack_pkg_path(self.pkg_name)
             if self.pkg_name != pkg_path["name"]:
-                print("[ERROR: Could not find install of {}]".format(self.pkg_name))
+                print("[ERROR: Could not find install of {0}]".format(self.pkg_name))
                 return -1
             else:
-                pkg_lnk_dir = "{}-install".format(self.pkg_name)
+                pkg_lnk_dir = "{0}-install".format(self.pkg_name)
                 if os.path.islink(pkg_lnk_dir):
                     os.unlink(pkg_lnk_dir)
                 print("")
-                print("[symlinking install to {}]").format(pjoin(self.dest_dir,pkg_lnk_dir))
+                print("[symlinking install to {0}]").format(pjoin(self.dest_dir,pkg_lnk_dir))
                 os.symlink(pkg_path["path"],os.path.abspath(pkg_lnk_dir))
                 hcfg_glob = glob.glob(pjoin(pkg_lnk_dir,"*.cmake"))
                 if len(hcfg_glob) > 0:
@@ -515,7 +515,7 @@ class SpackEnv(UberEnv):
                     hcfg_fname = os.path.split(hcfg_path)[1]
                     if os.path.islink(hcfg_fname):
                         os.unlink(hcfg_fname)
-                    print("[symlinking host config file to {}]".format(pjoin(self.dest_dir,hcfg_fname)))
+                    print("[symlinking host config file to {0}]".format(pjoin(self.dest_dir,hcfg_fname)))
                     os.symlink(hcfg_path,hcfg_fname)
                 print("")
                 print("[install complete!]")
@@ -537,7 +537,7 @@ class SpackEnv(UberEnv):
         mirror_cmd = "spack/bin/spack "
         if self.opts["ignore_ssl_errors"]:
             mirror_cmd += "-k "
-        mirror_cmd += "mirror create -d {} --dependencies {}".format(mirror_path,
+        mirror_cmd += "mirror create -d {0} --dependencies {1}".format(mirror_path,
                                                                     self.pkg_name)
         return sexe(mirror_cmd, echo=True)
 
@@ -565,20 +565,20 @@ class SpackEnv(UberEnv):
 
         if existing_mirror_path and mirror_path != existing_mirror_path:
             # Existing mirror has different URL, error out
-            print("[removing existing spack mirror `{}` @ {}]".format(mirror_name,
+            print("[removing existing spack mirror `{0}` @ {1}]".format(mirror_name,
                                                                     existing_mirror_path))
             #
             # Note: In this case, spack says it removes the mirror, but we still
             # get errors when we try to add a new one, sounds like a bug
             #
-            sexe("spack/bin/spack mirror remove --scope=defaults {} ".format(mirror_name),
+            sexe("spack/bin/spack mirror remove --scope=defaults {0} ".format(mirror_name),
                 echo=True)
             existing_mirror_path = None
         if not existing_mirror_path:
             # Add if not already there
-            sexe("spack/bin/spack mirror add --scope=defaults {} {}".format(
+            sexe("spack/bin/spack mirror add --scope=defaults {0} {1}".format(
                     mirror_name, mirror_path), echo=True)
-            print("[using mirror {}]".format(mirror_path))
+            print("[using mirror {0}]".format(mirror_path))
 
     def find_spack_upstream(self, upstream_name):
         """
@@ -619,8 +619,8 @@ class SpackEnv(UberEnv):
             sexe("rm spack/etc/spack/defaults/upstreams.yaml")
             with open('spack/etc/spack/defaults/upstreams.yaml','w+') as upstreams_cfg_file:
                 upstreams_cfg_file.write("upstreams:\n")
-                upstreams_cfg_file.write("  {}:\n".format(upstream_name))
-                upstreams_cfg_file.write("    install_tree: {}\n".format(upstream_path))
+                upstreams_cfg_file.write("  {0}:\n".format(upstream_name))
+                upstreams_cfg_file.write("    install_tree: {0}\n".format(upstream_path))
 
 
 def find_osx_sdks():
@@ -660,8 +660,8 @@ def setup_osx_sdk_env_vars():
 
     env["MACOSX_DEPLOYMENT_TARGET"] = dep_tgt
     env["SDKROOT"] = sdk_root
-    print("[setting MACOSX_DEPLOYMENT_TARGET to {}]".format(env["MACOSX_DEPLOYMENT_TARGET"]))
-    print("[setting SDKROOT to {}]".format(env[ "SDKROOT"]))
+    print("[setting MACOSX_DEPLOYMENT_TARGET to {0}]".format(env["MACOSX_DEPLOYMENT_TARGET"]))
+    print("[setting SDKROOT to {0}]".format(env[ "SDKROOT"]))
 
 
 

--- a/uberenv.py
+++ b/uberenv.py
@@ -625,7 +625,9 @@ class SpackEnv(UberEnv):
         # this may fail general cases
         if self.opts["install"] and "+python" in full_spec:
             activate_cmd = "spack/bin/spack activate " + self.pkg_name
-            sexe(activate_cmd, echo=True)
+            res = sexe(activate_cmd, echo=True)
+            if res != 0:
+              return res
         # if user opt'd for an install, we want to symlink the final
         # install to an easy place:
         if self.opts["install"]:

--- a/uberenv.py
+++ b/uberenv.py
@@ -262,7 +262,7 @@ class UberEnv():
         try:
             setting_value = self.project_opts[setting]
         except (KeyError):
-            print("ERROR: {} must at least be defined in project.json".format(setting))
+            print("ERROR: {0} must at least be defined in project.json".format(setting))
             raise
         else:
             if self.opts[setting]:
@@ -593,7 +593,7 @@ class SpackEnv(UberEnv):
         if self.opts["ignore_ssl_errors"]:
             install_cmd += "-k "
         if not self.opts["install"]:
-            install_cmd += "dev-build -d {} -u {} ".format(self.pkg_src_dir,self.pkg_final_phase)
+            install_cmd += "dev-build -d {0} -u {1} ".format(self.pkg_src_dir, self.pkg_final_phase)
         else:
             install_cmd += "install "
             if self.opts["run_tests"]:

--- a/uberenv.py
+++ b/uberenv.py
@@ -47,7 +47,8 @@
 """
  file: uberenv.py
 
- description: automates using spack to install a project.
+ description: automates using a package manager to install a project.
+ Uses spack on Unix-based systems and Vcpkg on Windows-based systems.
 
 """
 
@@ -244,6 +245,7 @@ class UberEnv():
 
         # setup main package name
         self.pkg_name = self.project_opts["package_name"]
+
     def setup_paths_and_dirs(self):
         self.uberenv_path = os.path.split(os.path.abspath(__file__))[0]
 
@@ -824,16 +826,16 @@ def main():
     env.show_info()
 
 
-    ##########################################################
-    # we now have an instance of spack configured how we
-    # need it to build our tpls at this point there are two
-    # possible next steps:
+    ###########################################################
+    # we now have an instance of our package manager configured
+    # how we need it to build our tpls at this point there are
+    # two possible next steps:
     #
     # *) create a mirror of the packages
     #   OR
     # *) build
     #
-    ##########################################################
+    ###########################################################
     if opts["create_mirror"]:
         return env.create_mirror()
     else:


### PR DESCRIPTION
Upstreams changes made by @agcapps to Axom's version of ``uberenv`` for automated TPL generation on Windows using Vcpkg -- https://github.com/microsoft/vcpkg

Also updates comments and user docs to reflect the addition of Vcpkg.

See: https://github.com/LLNL/axom/blob/develop/scripts/uberenv for Axom's setup/usage.