### PR TITLE
Allow to use uberenv to only setup spack

### DIFF
--- a/uberenv.py
+++ b/uberenv.py
@@ -195,12 +195,12 @@ def parse_args():
                            " but can cause issues with macOS versions >= 10.13. "
                            " so it is disabled by default.")
 
-    # option to stop after spack config
-    parser.add_option("--spack-only",
+    # option to stop after spack download and setup
+    parser.add_option("--setup-only",
                       action="store_true",
-                      dest="spack_only",
+                      dest="setup_only",
                       default=False,
-                      help="Stops uberenv right after spack config. Spec has no effect")
+                      help="Only download and setup Spack. No further Spack command will be run.")
 
 
     ###############
@@ -777,7 +777,7 @@ def main():
     env.clean_build()
 
     # Allow to end uberenv after spack is ready
-    if opts["spack_only"]:
+    if opts["setup_only"]:
         return 0
 
     # Show the spec for what will be built

--- a/uberenv.py
+++ b/uberenv.py
@@ -195,6 +195,13 @@ def parse_args():
                            " but can cause issues with macOS versions >= 10.13. "
                            " so it is disabled by default.")
 
+    # option to stop after spack config
+    parser.add_option("--spack-only",
+                      action="store_true",
+                      dest="spack_only",
+                      default=False,
+                      help="Stops uberenv right after spack config. Spec has no effect")
+
 
     ###############
     # parse args
@@ -768,6 +775,10 @@ def main():
 
     # Clean the build
     env.clean_build()
+
+    # Allow to end uberenv after spack is ready
+    if opts["spack_only"]:
+        return 0
 
     # Show the spec for what will be built
     env.show_info()


### PR DESCRIPTION
This comes from my current work on MFEM CI, but could benefit others:

In CI, it is valuable to cache `uberenv_libs` at its original state (spack downloaded and configured).
That way we can skip spack download in all the jobs (and replace it with a local cache download).

For more about setting up such a cache, see: 
https://github.com/mfem/mfem/blob/5a4025dc841baab5f85d33d0febbf2d20ba465bb/.gitlab/quartz.yml#L25
https://github.com/mfem/mfem/blob/5a4025dc841baab5f85d33d0febbf2d20ba465bb/.gitlab/quartz.yml#L35