### PR TITLE
Introduce minimum changes to get uberenv usable in submodule

### DIFF
--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -135,7 +135,7 @@ If the target Spack package supports Spack's testing hooks, you can run tests du
 For details on Spack's spec syntax, see the `Spack Specs & dependencies <http://spack.readthedocs.io/en/latest/basic_usage.html#specs-dependencies>`_ documentation.
 
 
-Uberenv looks for configuration yaml files under ``scripts/uberenv/spack_config/{platform}`` or you can use the **--spack-config-dir** option to specify a directory with compiler and packages yaml files to use with Spack. See the `Spack Compiler Configuration <http://spack.readthedocs.io/en/latest/getting_started.html#manual-compiler-configuration>`_
+Uberenv looks for configuration yaml files under ``scripts/uberenv/spack_configs/{platform}`` or under ``.uberenv/spack_configs/{platform}``. You may also use the **--spack-config-dir** option to specify a directory with compiler and packages yaml files to use with Spack. See the `Spack Compiler Configuration <http://spack.readthedocs.io/en/latest/getting_started.html#manual-compiler-configuration>`_
 and `Spack System Packages
 <http://spack.readthedocs.io/en/latest/getting_started.html#system-packages>`_
 documentation for details.
@@ -167,6 +167,9 @@ Part of the configuration can also be addressed using a json file. By default, i
   spack_activate       **None**                   Spack packages to activate                       **None**
  ==================== ========================== ================================================ =======================================
 
+However, Uberenv config can also be setup to sit in a location external to the uberenv directory itself. In particular, if no ``project.json`` file is found there, the script will look for ``.uberenv/config.json`` recursively in parent directories. The typical usage is to place it at the root directory of the project.
+
+When ``.uberenv/config.json`` is found, it is assumed that ``.uberenv`` also contains the ``packages`` and the ``spack_configs`` directories.
 
 Optimization
 ------------
@@ -187,7 +190,7 @@ Project Settings
 
 A few notes on using ``uberenv.py`` in a new project:
 
-* For an example of how to craft a ``project.json`` file a target project, see: `Conduit's project.json file <https://github.com/LLNL/conduit/tree/master/scripts/uberenv/project.json>`_
+* For an example of how to craft a ``project.json`` / ``.uberenv/config.json`` file a target project, see: `Conduit's project.json file <https://github.com/LLNL/conduit/tree/master/scripts/uberenv/project.json>`_
 
 * ``uberenv.py`` hot copies ``packages`` to the cloned Spack install, this allows you to easily version control any Spack package overrides necessary
 

--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -141,7 +141,7 @@ Uberenv looks for configuration yaml files under ``scripts/uberenv/spack_configs
 * ``{spack_configs_path}`` can be specified in the json config file.
 
 You may instead use the **--spack-config-dir** option to enforce the use of a specific directory. As long as it provides Uberenv with the yaml files to use with Spack.
-See the `Spack Compiler Configuration <http://spack.readthedocs.io/en/latest/getting_started.html#manual-compiler-configuration>`_ and `Spack System Packages <http://spack.readthedocs.io/en/latest/getting_started.html#system-packages>` documentation for details.
+See the `Spack Compiler Configuration <http://spack.readthedocs.io/en/latest/getting_started.html#manual-compiler-configuration>`_ and `Spack System Packages <http://spack.readthedocs.io/en/latest/getting_started.html#system-packages>`_ documentation for details.
 
 .. note::
     The bootstrapping process ignores ``~/.spack/compilers.yaml`` to avoid conflicts
@@ -171,7 +171,7 @@ Part of the configuration can also be addressed using a json file. By default, i
   spack_activate       **None**                   Spack packages to activate                       **None**
  ==================== ========================== ================================================ =======================================
 
-However, Uberenv config can also be setup to sit in a location external to the uberenv directory itself. In particular when Uberenv is used as a submodule. Uberenv identifies such a case when no ``project.json`` file is found next to the script. It will then look for ``.uberenv_config.json`` recursively in parent directories. The typical usage is to place it at the root directory of the project.
+However, Uberenv configuration may instead sit in a location external to the uberenv directory itself. In particular when Uberenv is used as a submodule. Uberenv identifies such a case when no ``project.json`` file is found next to the script. It will then look for ``.uberenv_config.json`` recursively in parent directories. The typical usage is to place it at the root directory of the project.
 
 When used as a submodule ``.uberenv_config.json`` should define both ``spack_configs_path`` and ``spack_packages_path``, providing Uberenv with the respective location of ``spack_configs`` and ``packages`` directories. Indeed, they cannot sit next to ``uberenv.py`` as per default, since Uberenv repo does not provide them.
 
@@ -197,5 +197,4 @@ A few notes on using ``uberenv.py`` in a new project:
 * For an example of how to craft a ``project.json`` / ``.uberenv_config.json`` file a target project, see: `Axom's project.json file <https://github.com/LLNL/axom/tree/develop/scripts/uberenv/project.json>`_
 
 * ``uberenv.py`` hot copies ``packages`` to the cloned Spack install, this allows you to easily version control any Spack package overrides necessary
-
 

--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -45,7 +45,7 @@
 .. _building_with_uberenv:
 
 Uberenv
-~~~~~~~~~~~~~~~
+~~~~~~~
 
 **Uberenv** automates using `Spack <ttp://www.spack.io>`_ to build and deploy software.
 
@@ -57,21 +57,22 @@ https://github.com/llnl/uberenv/ repo is used to hold the latest reference versi
 
 
 uberenv.py
-~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~
 
-``uberenv.py`` is a single file python script that automates fetching Spack, building and installing third party dependencies, and can optionally install packages as well.  To automate the full install process, ``uberenv.py`` uses a target Spack package along with extra settings such as Spack compiler and external third party package details for common HPC platforms.
+``uberenv.py`` is a single file python script that automates fetching Spack, building and installing third party dependencies, and can optionally install top-level packages as well. To automate the full install process, ``uberenv.py`` uses a target Spack package along with extra settings such as Spack compiler and external third party package details for common HPC platforms.
 
-``uberenv.py`` is included directly in a project's source code repo in the folder: ``scripts/uberenv/``
-This folder is also used to store extra Spack and Uberenv configuration files unique to the target project. ``uberenv.py`` uses a ``project.json`` file to specify project details, including the target Spack package name and which Spack repo is used.  Conduit's source repo serves as an example for Uberenv and Spack configuration files, etc:
+``uberenv.py`` is included directly in a project's source code repo, usually in the folder: ``scripts/uberenv/``
+By default, this folder is also used to store extra Spack and Uberenv configuration files unique to the target project. ``uberenv.py`` uses a ``project.json`` file to specify project details, including the target Spack package name and which Spack repo is used.  Conduit's source repo serves as an example for Uberenv and Spack configuration files, etc:
 
 https://github.com/LLNL/conduit/tree/master/scripts/uberenv
 
+Uberenv can also be used as a submodule. In that case, it is required to provide a configuration file named ``.uberenv_config.json`` in a parent directory. This file is similar to ``project.json`` in purpose, but should additionally provide the entries ``spack_configs_path`` and ``spack_packages_path``. Details in :ref:`project_configuration`.
 
-``uberenv.py`` is developed by LLNL in support of the `Ascent <http://github.com/alpine-dav/ascent/>`_, Axom, and `Conduit <https://github.com/llnl/conduit>`_  projects.
+``uberenv.py`` is developed by LLNL originally in support of the `Ascent <http://github.com/alpine-dav/ascent/>`_, Axom, and `Conduit <https://github.com/llnl/conduit>`_  projects. It is now also used in `Umpire <https://github.com/llnl/umpire>`, `CHAI <https://github.com/llnl/CHAI>`, `RAJA <https://github.com/llnl/RAJA>` and `Serac <https://github.com/llnl/serac>` for example.
 
 
 Command Line Options
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~
 
 Build configuration
 -------------------
@@ -135,10 +136,12 @@ If the target Spack package supports Spack's testing hooks, you can run tests du
 For details on Spack's spec syntax, see the `Spack Specs & dependencies <http://spack.readthedocs.io/en/latest/basic_usage.html#specs-dependencies>`_ documentation.
 
 
-Uberenv looks for configuration yaml files under ``scripts/uberenv/spack_configs/{platform}`` or under ``.uberenv/spack_configs/{platform}``. You may also use the **--spack-config-dir** option to specify a directory with compiler and packages yaml files to use with Spack. See the `Spack Compiler Configuration <http://spack.readthedocs.io/en/latest/getting_started.html#manual-compiler-configuration>`_
-and `Spack System Packages
-<http://spack.readthedocs.io/en/latest/getting_started.html#system-packages>`_
-documentation for details.
+Uberenv looks for configuration yaml files under ``scripts/uberenv/spack_configs/{platform}`` or under ``{spack_config_paths}/{platform}``, where:
+* ``{platform}`` must match the platform determined by uberenv.
+* ``{spack_configs_path}`` can be specified in the json config file.
+
+You may instead use the **--spack-config-dir** option to enforce the use of a specific directory. As long as it provides Uberenv with the yaml files to use with Spack.
+See the `Spack Compiler Configuration <http://spack.readthedocs.io/en/latest/getting_started.html#manual-compiler-configuration>`_ and `Spack System Packages <http://spack.readthedocs.io/en/latest/getting_started.html#system-packages>` documentation for details.
 
 .. note::
     The bootstrapping process ignores ``~/.spack/compilers.yaml`` to avoid conflicts
@@ -149,6 +152,7 @@ destination directory. It then uses Spack to build and install the target packag
 ``spack/opt/spack/``. Finally, the target package generates a host-config file ``{hostname}.cmake``, which is
 copied to destination directory. This file specifies the compiler settings and paths to all of the dependencies.
 
+.. _project_configuration:
 
 Project configuration
 ---------------------
@@ -167,9 +171,9 @@ Part of the configuration can also be addressed using a json file. By default, i
   spack_activate       **None**                   Spack packages to activate                       **None**
  ==================== ========================== ================================================ =======================================
 
-However, Uberenv config can also be setup to sit in a location external to the uberenv directory itself. In particular, if no ``project.json`` file is found there, the script will look for ``.uberenv/config.json`` recursively in parent directories. The typical usage is to place it at the root directory of the project.
+However, Uberenv config can also be setup to sit in a location external to the uberenv directory itself. In particular when Uberenv is used as a submodule. Uberenv identifies such a case when no ``project.json`` file is found next to the script. It will then look for ``.uberenv_config.json`` recursively in parent directories. The typical usage is to place it at the root directory of the project.
 
-When ``.uberenv/config.json`` is found, it is assumed that ``.uberenv`` also contains the ``packages`` and the ``spack_configs`` directories.
+When used as a submodule ``.uberenv_config.json`` should define both ``spack_configs_path`` and ``spack_packages_path``, providing Uberenv with the respective location of ``spack_configs`` and ``packages`` directories. Indeed, they cannot sit next to ``uberenv.py`` as per default, since Uberenv repo does not provide them.
 
 Optimization
 ------------
@@ -186,11 +190,11 @@ Optimization
 
 
 Project Settings
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~
 
 A few notes on using ``uberenv.py`` in a new project:
 
-* For an example of how to craft a ``project.json`` / ``.uberenv/config.json`` file a target project, see: `Conduit's project.json file <https://github.com/LLNL/conduit/tree/master/scripts/uberenv/project.json>`_
+* For an example of how to craft a ``project.json`` / ``.uberenv_config.json`` file a target project, see: `Axom's project.json file <https://github.com/LLNL/axom/tree/develop/scripts/uberenv/project.json>`_
 
 * ``uberenv.py`` hot copies ``packages`` to the cloned Spack install, this allows you to easily version control any Spack package overrides necessary
 

--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -68,7 +68,7 @@ https://github.com/LLNL/conduit/tree/master/scripts/uberenv
 
 Uberenv can also be used as a submodule. In that case, it is required to provide a configuration file named ``.uberenv_config.json`` in a parent directory. This file is similar to ``project.json`` in purpose, but should additionally provide the entries ``spack_configs_path`` and ``spack_packages_path``. Details in :ref:`project_configuration`.
 
-``uberenv.py`` is developed by LLNL originally in support of the `Ascent <http://github.com/alpine-dav/ascent/>`_, Axom, and `Conduit <https://github.com/llnl/conduit>`_  projects. It is now also used in `Umpire <https://github.com/llnl/umpire>`, `CHAI <https://github.com/llnl/CHAI>`, `RAJA <https://github.com/llnl/RAJA>` and `Serac <https://github.com/llnl/serac>` for example.
+``uberenv.py`` is developed by LLNL originally in support of the `Ascent <http://github.com/alpine-dav/ascent/>`_, Axom, and `Conduit <https://github.com/llnl/conduit>`_  projects. It is now also used in `Umpire <https://github.com/llnl/umpire>`_, `CHAI <https://github.com/llnl/CHAI>`_, `RAJA <https://github.com/llnl/RAJA>`_ and `Serac <https://github.com/llnl/serac>`_ for example.
 
 
 Command Line Options

--- a/uberenv.py
+++ b/uberenv.py
@@ -230,10 +230,6 @@ def uberenv_script_dir():
     # returns the directory of the uberenv.py script
     return os.path.dirname(os.path.realpath(__file__))
 
-def uberenv_config_dir(project_json_file):
-    # returns the directory of the uberenv.py script
-    return os.path.dirname(os.path.realpath(project_json_file))
-
 def load_json_file(json_file):
     # reads json file
     return json.load(open(json_file))
@@ -278,7 +274,6 @@ class UberEnv():
         print("[uberenv options: {}]".format(str(self.opts)))
 
     def setup_paths_and_dirs(self):
-        # Script dir
         self.uberenv_path = uberenv_script_dir()
 
     def set_from_args_or_json(self,setting):
@@ -857,5 +852,4 @@ def main():
 
 if __name__ == "__main__":
     sys.exit(main())
-
 

--- a/uberenv.py
+++ b/uberenv.py
@@ -251,7 +251,7 @@ def find_project_config(opts):
         while not end_of_search:
             if os.path.dirname(lookup_path) == lookup_path:
                 end_of_search = True
-            project_json_file = pjoin(lookup_path,".uberenv.json")
+            project_json_file = pjoin(lookup_path,".uberenv","config.json")
             if os.path.isfile(project_json_file):
                 return project_json_file
             else:

--- a/uberenv.py
+++ b/uberenv.py
@@ -446,13 +446,21 @@ class SpackEnv(UberEnv):
                 print("[info: using spack commit {}]".format(sha1))
                 sexe("git stash", echo=True)
                 sexe("git fetch origin {0}".format(sha1),echo=True)
-                sexe("git checkout {0}".format(sha1),echo=True)
+                res = sexe("git checkout {0}".format(sha1),echo=True)
+                if res != 0:
+                    # Usually untracked files that would be overwritten
+                    print("[ERROR: Git failed to checkout]")
+                    sys.exit(-1)
 
         if self.opts["spack_pull"]:
             # do a pull to make sure we have the latest
             os.chdir(pjoin(self.dest_dir,"spack"))
             sexe("git stash", echo=True)
             sexe("git pull", echo=True)
+            if res != 0:
+                #Usually untracked files that would be overwritten
+                print("[ERROR: Git failed to pull]")
+                sys.exit(-1)
 
     def disable_spack_config_scopes(self,spack_dir):
         # disables all config scopes except "defaults", which we will
@@ -563,7 +571,7 @@ class SpackEnv(UberEnv):
             if not self.opts["install"]:
                 install_cmd += "dev-build --quiet -d {} ".format(self.pkg_src_dir)
                 if self.pkg_final_phase:
-                    install_cmd += "-u {} ".format(self.pkg_final_phase)                
+                    install_cmd += "-u {} ".format(self.pkg_final_phase)
             else:
                 install_cmd += "install "
                 if self.opts["run_tests"]:

--- a/uberenv.py
+++ b/uberenv.py
@@ -247,16 +247,16 @@ def is_windows():
 def find_project_config(opts):
     project_json_file = opts["project_json"]
     lookup_path = pabs(os.path.join(uberenv_script_dir(), os.pardir))
-    # Default case: project.json seats next to uberenv.py or is given on command line.
+    # Default case: "project.json" seats next to uberenv.py or is given on command line.
     if os.path.isfile(project_json_file):
         return project_json_file
-    # Submodule case: .uberenv.json is in one of the parent dir
+    # Submodule case: ".uberenv_config.json" should be in one of the parent dir
     else:
         end_of_search = False
         while not end_of_search:
             if os.path.dirname(lookup_path) == lookup_path:
                 end_of_search = True
-            project_json_file = pjoin(lookup_path,".uberenv","config.json")
+            project_json_file = pjoin(lookup_path,".uberenv_config.json")
             if os.path.isfile(project_json_file):
                 return project_json_file
             else:

--- a/uberenv.py
+++ b/uberenv.py
@@ -277,6 +277,7 @@ class UberEnv():
         print("[uberenv options: {}]".format(str(self.opts)))
 
     def setup_paths_and_dirs(self):
+        self.uberenv_path = uberenv_script_dir()
         self.uberenv_conf_path = uberenv_config_dir(self.opts["project_json"])
 
     def set_from_args_or_json(self,setting):
@@ -367,7 +368,7 @@ class SpackEnv(UberEnv):
         if os.path.isdir(self.dest_spack):
             print("[info: destination '{}' already exists]".format(self.dest_spack))
 
-        self.pkg_src_dir = os.path.join(self.uberenv_conf_path,self.pkg_src_dir)
+        self.pkg_src_dir = os.path.join(self.uberenv_path,self.pkg_src_dir)
         if not os.path.isdir(self.pkg_src_dir):
             print("[ERROR: package_source_dir '{}' does not exist]".format(self.pkg_src_dir))
             sys.exit(-1)


### PR DESCRIPTION
This addresses #31 

The strategy here was to introduce as few changes as possible.
In fact only a few changes were required:

- looking for `.uberenv/config.json` in parent directories if `project.json` is not found locally.
- defining uberenv_conf_path as the parent directory of the configuration file, and retrieve `spack_configs` and `packages` from there.

As a result, Uberenv works as before in the following configuration:

Project
|_ .uberenv
&ensp;|_ config.json
&ensp;|_ spack_configs
&ensp;|_ packages
|_ scripts
&ensp;|_ uberenv
&ensp;&ensp;|_ uberenv.py