### PR TITLE
Make mirror configurable in spack_config

### DIFF
--- a/uberenv.py
+++ b/uberenv.py
@@ -443,17 +443,23 @@ class SpackEnv(UberEnv):
         # copy in "defaults" config.yaml
         config_yaml = os.path.abspath(pjoin(self.uberenv_path,"spack_configs","config.yaml"))
         sexe("cp {} {}/".format(config_yaml, spack_etc_defaults_dir ), echo=True)
+        mirrors_yaml = os.path.abspath(pjoin(self.uberenv_path,"spack_configs","mirrors.yaml"))
+        sexe("cp {} {}/".format(mirrors_yaml, spack_etc_defaults_dir ), echo=True)
 
         # copy in other settings per platform
         if not cfg_dir is None:
             print("[copying uberenv compiler and packages settings from {0}]".format(cfg_dir))
 
             config_yaml    = pjoin(cfg_dir,"config.yaml")
+            mirrors_yaml    = pjoin(cfg_dir,"mirrors.yaml")
             compilers_yaml = pjoin(cfg_dir,"compilers.yaml")
             packages_yaml  = pjoin(cfg_dir,"packages.yaml")
 
             if os.path.isfile(config_yaml):
                 sexe("cp {} {}/".format(config_yaml , spack_etc_defaults_dir ), echo=True)
+
+            if os.path.isfile(mirrors_yaml):
+                sexe("cp {} {}/".format(mirrors_yaml , spack_etc_defaults_dir ), echo=True)
 
             if os.path.isfile(compilers_yaml):
                 sexe("cp {} {}/".format(compilers_yaml, spack_etc_defaults_dir ), echo=True)


### PR DESCRIPTION
Addresses #32 

This is a basic proposal to address the issue.
However it is not protected against some cases, like if someone configures a mirror in the json file, and then another on command line.