### PR TITLE
Adds support for Vcpkg as a Windows package manager (take2)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2014-2020, Lawrence Livermore National Security, LLC.
+# Copyright (c) 2014-2021, Lawrence Livermore National Security, LLC.
 #
 # Produced at the Lawrence Livermore National Laboratory
 #

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2014-2018, Lawrence Livermore National Security, LLC.
+Copyright (c) 2014-2020, Lawrence Livermore National Security, LLC.
 
 Produced at the Lawrence Livermore National Laboratory
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2014-2020, Lawrence Livermore National Security, LLC.
+Copyright (c) 2014-2021, Lawrence Livermore National Security, LLC.
 
 Produced at the Lawrence Livermore National Laboratory
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
 # uberenv
-Automates using Spack (https://www.spack.io/) to build and deploy software.
+Automates using a package manager to build and deploy software.
 
-Uberenv is a short python script that helps automate using Spack to build
-third-party dependencies for development and to deploy Spack packages. 
+Uberenv is a python script that helps automate building
+third-party dependencies for development and deployment. 
 
-Uberenv was released as part of the Conduit (https://github.com/LLNL/conduit/). It is included in-source in several projects, this repo is used to hold the latest reference version.
+Uberenv use Spack (https://www.spack.io/) on Unix-based systems (e.g. Linux and macOS)
+and Vcpkg (https://github.com/microsoft/vcpkg) on Windows systems.
+
+Uberenv was released as part of the Conduit project (https://github.com/LLNL/conduit/). 
+It is included in-source in several projects, this repo is used to hold the latest reference version.
 
 For more details, see Uberenv's documention:
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Automates using a package manager to build and deploy software.
 Uberenv is a python script that helps automate building
 third-party dependencies for development and deployment. 
 
-Uberenv use Spack (https://www.spack.io/) on Unix-based systems (e.g. Linux and macOS)
+Uberenv uses Spack (https://www.spack.io/) on Unix-based systems (e.g. Linux and macOS)
 and Vcpkg (https://github.com/microsoft/vcpkg) on Windows systems.
 
 Uberenv was released as part of the Conduit project (https://github.com/LLNL/conduit/). 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -13,6 +13,8 @@ The Uberenv project release numbers follow [Semantic Versioning](http://semver.o
 - Allow projects to force specifying `--prefix` on command line via new project option:
   `force_commandline_prefix`.  This is useful when the default `uberenv_libs` can not exist
   inside of your project's source repository.
+- Adds support for Windows builds using [Vcpkg].
+- Adds the `--triplet` command line argument for setting the Vcpkg build configuration.
 
 ### Changed
 - Added ability to have multiple packages directories that will get copied into spack on top of
@@ -23,3 +25,6 @@ The Uberenv project release numbers follow [Semantic Versioning](http://semver.o
 - Reduce Spack's git history to a bare minimum
 
 ### Fixed
+
+
+[Vcpkg]: https://github.com/microsoft/vcpkg

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 ###############################################################################
-# Copyright (c) 2015-2019, Lawrence Livermore National Security, LLC.
+# Copyright (c) 2015-2021, Lawrence Livermore National Security, LLC.
 #
 # Produced at the Lawrence Livermore National Laboratory
 #
@@ -101,7 +101,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Uberenv'
-copyright = u'Copyright (c) 2015-2019, LLNS'
+copyright = u'Copyright (c) 2015-2021, LLNS'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -47,11 +47,13 @@
 Uberenv
 ~~~~~~~
 
-**Uberenv** automates using `Spack <https://spack.io>`_ to build and deploy software.
+**Uberenv** automates using a package manager to build and deploy software.
+It uses `Spack <http://www.spack.io>`_ on Unix-based systems (e.g. Linux and macOS)
+and `Vcpkg <https://github.com/microsoft/vcpkg>`_ on Windows systems.
 
-Many projects leverage `Spack <https://spack.io>`_ to help build the software dependencies needed to
-develop and deploy their projects on HPC systems. Uberenv is a python script that helps automate using Spack to build
-third-party dependencies for development and to deploy Spack packages.
+Many projects leverage package managers, like Spack and Vcpkg, to help build the software dependencies needed to
+develop and deploy their projects on HPC systems. Uberenv is a python script that helps automate usage of a package manager to build
+third-party dependencies for development and deployment.
 
 Uberenv was released as part of Conduit (https://github.com/LLNL/conduit/). It is included in-source in several projects. The
 https://github.com/llnl/uberenv/ repo is used to hold the latest reference version of Uberenv.
@@ -60,25 +62,28 @@ https://github.com/llnl/uberenv/ repo is used to hold the latest reference versi
 uberenv.py
 ~~~~~~~~~~
 
-Uberenv is a single file python script that automates fetching Spack, building and installing third party dependencies,
-and can optionally install top-level packages as well. To automate the full install process, Uberenv uses a target Spack
-package along with extra settings such as Spack compiler and external third party package details for common HPC platforms.
+Uberenv is a single file python script (``uberenv.py``) that automates fetching Spack or Vcpkg, building and installing third party dependencies,
+and can optionally install top-level packages as well. To automate the full install process, Uberenv uses a target Spack or Vcpkg
+package along with extra settings such as compilers and external third party package details for common HPC platforms.
 
-Uberenv is included directly in a project's source code repo, usually in the folder: ``scripts/uberenv/``
-By default, this folder is also used to store extra Spack and Uberenv configuration files unique to the target project.
-Uberenv uses a ``project.json`` file to specify project details, including the target Spack package name and which
-Spack repo is used.  Conduit's source repo serves as an example for Uberenv and Spack configuration files, etc:
+Uberenv is included directly in a project's source code repo, usually in the folder: ``scripts/uberenv/``.
+This folder is also used to store extra configuration files unique to the target project.
+Uberenv uses a ``project.json`` file to specify project details, including the target package name 
+and the base branch or commit in the package manager.  
+
+Conduit's source repo serves as an example for Uberenv and Spack configuration files, etc:
 
 https://github.com/LLNL/conduit/tree/master/scripts/uberenv
 
-Uberenv can also be used as a submodule. In that case, it is required to provide a configuration file named
+Uberenv can also be used as a submodule of the user project, where one must provide a configuration file named
 ``.uberenv_config.json`` in a parent directory. This file is similar to ``project.json`` in purpose, but should
-additionally provide the entries ``spack_configs_path`` and ``spack_packages_path``. Details in :ref:`project_configuration`.
+additionally provide the entries ``spack_configs_path`` and ``spack_packages_path``. 
+Additional details are provided in :ref:`project_configuration`.
 
-Uberenv is developed by LLNL originally in support of the `Ascent <https://github.com/alpine-dav/ascent/>`_,
+Uberenv is developed by LLNL, originally in support of the `Ascent <https://github.com/alpine-dav/ascent/>`_,
 `Axom <https://github.com/llnl/axom>`_, and `Conduit <https://github.com/llnl/conduit>`_  projects. It is now also used
-in `Umpire <https://github.com/llnl/umpire>`_, `CHAI <https://github.com/llnl/CHAI>`_, `RAJA <https://github.com/llnl/RAJA>`_
-and `Serac <https://github.com/llnl/serac>`_ for example.
+by `Umpire <https://github.com/llnl/umpire>`_, `CHAI <https://github.com/llnl/CHAI>`_, `RAJA <https://github.com/llnl/RAJA>`_
+and `Serac <https://github.com/llnl/serac>`_, among others.
 
 
 Command Line Options
@@ -101,6 +106,7 @@ Uberenv has a few options that allow you to control how dependencies are built:
   ``--install``           Fully install target, not just dependencies    **False**
   ``--run_tests``         Invoke tests during build and against install  **False**
   ``--project-json``      File for project specific settings             See :ref:`project_configuration`
+  ``--triplet``           (vcpkg) Target architecture and linkage        ``x86-Windows``
  ======================= ============================================== ================================================
 
 The ``-k`` option exists for sites where SSL certificate interception undermines fetching
@@ -128,6 +134,14 @@ Default invocation on OSX:
                                       --spec %clang \
                                       --spack-config-dir scripts/uberenv/spack_configs/darwin/
 
+Default invocation on Windows:
+
+.. code:: bash
+
+    python scripts/uberenv/uberenv.py --prefix uberenv_libs \
+                                      --triplet x86-windows
+
+See `Vcpkg user docs <https://vcpkg.readthedocs.io/en/latest/users/triplets/>`_ for more information about triplets.
 
 Use the ``--install`` option to install the target package (not just its development dependencies):
 
@@ -185,16 +199,21 @@ Project settings are as follows:
   package_final_phase      ``--package-final-phase``  Controls after which phase Spack should stop     **None**
   package_source_dir       ``--package-source-dir``   Controls the source directory Spack should use   **None**
   force_commandline_prefix **None**                   Force user to specify `--prefix` on command line ``False``
-  spack_url                **None**                   Url where to download Spack                      ``https://github.com/spack/spack.git``
+  spack_url                **None**                   Download url for Spack                           ``https://github.com/spack/spack.git``
   spack_commit             **None**                   Spack commit to checkout                         **None**
   spack_activate           **None**                   Spack packages to activate                       **None**
   spack_configs_path       **None**                   Directory with Spack configs to be copied        ``spack_configs``
   spack_packages_path      **None**                   Directory with Spack packages to be copied       ``packages``
+  vcpkg_url                **None**                   Download url for Vcpkg                          ``https://github.com/microsoft/vcpkg``
+  vcpkg_branch             **None**                   Vcpkg branch to checkout                         ``master``
+  vcpkg_commit             **None**                   Vcpkg commit to checkout                         **None**
  ========================= ========================== ================================================ =======================================
 
+If a ``spack_commit`` is present, it supercedes the ``spack_branch`` option, and similarly for ``vcpkg_commit`` and ``vcpkg_branch``.
+
 When used as a submodule ``.uberenv_config.json`` should define both ``spack_configs_path`` and ``spack_packages_path``,
-providing Uberenv with the respective location of ``spack_configs`` and ``packages`` directories. Indeed, they cannot sit next to
-``uberenv.py`` as per default, since the Uberenv repo does not provide them.
+providing Uberenv with the respective location of ``spack_configs`` and ``packages`` directories. 
+Note that they cannot sit next to ``uberenv.py``, since by default, the Uberenv repo does not provide them.
 
 Uberenv forcefully copies all directories that exist under `spack_packages_path` to the cloned Spack in order that they are given.
 This allows you to easily version control any Spack package overrides necessary.
@@ -217,4 +236,7 @@ Uberenv also features options to optimize the installation
   ``--create-mirror``  Creates a Spack mirror at specified location   **None**
   ``--upstream``       Location of a Spack upstream                   **None**
  ===================== ============================================== ================================================
+
+.. note::
+    These options are only currently available for spack.
 

--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -1,5 +1,5 @@
 .. ############################################################################
-.. # Copyright (c) 2014-2020, Lawrence Livermore National Security, LLC.
+.. # Copyright (c) 2014-2021, Lawrence Livermore National Security, LLC.
 .. #
 .. # Produced at the Lawrence Livermore National Laboratory
 .. #

--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -52,7 +52,7 @@ It uses `Spack <http://www.spack.io>`_ on Unix-based systems (e.g. Linux and mac
 and `Vcpkg <https://github.com/microsoft/vcpkg>`_ on Windows systems.
 
 Many projects leverage package managers, like Spack and Vcpkg, to help build the software dependencies needed to
-develop and deploy their projects on HPC systems. Uberenv is a python script that helps automate usage of a package manager to build
+develop and deploy their projects on HPC systems. Uberenv is a python script that helps automate the usage of a package manager to build
 third-party dependencies for development and deployment.
 
 Uberenv was released as part of Conduit (https://github.com/LLNL/conduit/). It is included in-source in several projects. The
@@ -78,7 +78,7 @@ https://github.com/LLNL/conduit/tree/master/scripts/uberenv
 Uberenv can also be used as a submodule of the user project, where one must provide a configuration file named
 ``.uberenv_config.json`` in a parent directory. This file is similar to ``project.json`` in purpose, but should
 additionally provide the entries ``spack_configs_path`` and ``spack_packages_path``. 
-Additional details are provided in :ref:`project_configuration`.
+See :ref:`project_configuration` for more details.
 
 Uberenv is developed by LLNL, originally in support of the `Ascent <https://github.com/alpine-dav/ascent/>`_,
 `Axom <https://github.com/llnl/axom>`_, and `Conduit <https://github.com/llnl/conduit>`_  projects. It is now also used
@@ -239,4 +239,3 @@ Uberenv also features options to optimize the installation
 
 .. note::
     These options are only currently available for spack.
-

--- a/gen_spack_env_script.py
+++ b/gen_spack_env_script.py
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2015-2019, Lawrence Livermore National Security, LLC.
+# Copyright (c) 2015-2021, Lawrence Livermore National Security, LLC.
 #
 # Produced at the Lawrence Livermore National Laboratory
 #

--- a/uberenv.py
+++ b/uberenv.py
@@ -771,7 +771,9 @@ class SpackEnv(UberEnv):
         # this may fail general cases
         if self.opts["install"] and "+python" in full_spec:
             activate_cmd = "spack/bin/spack activate /" + self.spec_hash
-            sexe(activate_cmd, echo=True)
+            res = sexe(activate_cmd, echo=True)
+            if res != 0:
+              return res
         # if user opt'd for an install, we want to symlink the final
         # install to an easy place:
         if self.opts["install"] or self.use_install:

--- a/uberenv.py
+++ b/uberenv.py
@@ -1,7 +1,7 @@
 #!/bin/sh
 "exec" "python" "-u" "-B" "$0" "$@"
 ###############################################################################
-# Copyright (c) 2014-2020, Lawrence Livermore National Security, LLC.
+# Copyright (c) 2014-2021, Lawrence Livermore National Security, LLC.
 #
 # Produced at the Lawrence Livermore National Laboratory
 #

--- a/uberenv.py
+++ b/uberenv.py
@@ -72,7 +72,7 @@ from os.path import abspath as pabs
 def sexe(cmd,ret_output=False,echo=False):
     """ Helper for executing shell commands. """
     if echo:
-        print("[exe: {}]".format(cmd))
+        print("[exe: {0}]".format(cmd))
     if ret_output:
         p = subprocess.Popen(cmd,
                              shell=True,
@@ -214,7 +214,7 @@ def parse_args():
     if not opts["spack_config_dir"] is None:
         opts["spack_config_dir"] = pabs(opts["spack_config_dir"])
         if not os.path.isdir(opts["spack_config_dir"]):
-            print("[ERROR: invalid spack config dir: {} ]".format(opts["spack_config_dir"]))
+            print("[ERROR: invalid spack config dir: {0} ]".format(opts["spack_config_dir"]))
             sys.exit(-1)
     # if rel path is given for the mirror, we need to evaluate here -- before any
     # chdirs to avoid confusion related to what it is relative to.
@@ -294,7 +294,7 @@ class UberEnv():
         try:
             setting_value = self.project_opts[setting]
         except (KeyError):
-            print("ERROR: {} must at least be defined in project.json".format(setting))
+            print("ERROR: {0} must at least be defined in project.json".format(setting))
             raise
         else:
             if self.opts[setting]:
@@ -305,7 +305,7 @@ class UberEnv():
         try:
             setting_value = self.project_opts[setting]
         except (KeyError):
-            print("ERROR: {} must at least be defined in project.json".format(setting))
+            print("ERROR: {0} must at least be defined in project.json".format(setting))
             raise
         return setting_value
 
@@ -350,13 +350,13 @@ class SpackEnv(UberEnv):
                 opts["spec"] = "%clang"
             else:
                 opts["spec"] = "%gcc"
-            self.opts["spec"] = "@{}{}".format(self.pkg_version,opts["spec"])
+            self.opts["spec"] = "@{0}{1}".format(self.pkg_version,opts["spec"])
         elif not opts["spec"].startswith("@"):
-            self.opts["spec"] = "@{}{}".format(self.pkg_version,opts["spec"])
+            self.opts["spec"] = "@{0}{1}".format(self.pkg_version,opts["spec"])
         else:
-            self.opts["spec"] = "{}".format(opts["spec"])
+            self.opts["spec"] = "{0}".format(opts["spec"])
 
-        print("[spack spec: {}]".format(self.opts["spec"]))
+        print("[spack spec: {0}]".format(self.opts["spec"]))
 
 
     def append_path_to_packages_paths(self, path, errorOnNonexistant=True):
@@ -421,23 +421,23 @@ class SpackEnv(UberEnv):
         if not os.path.isdir(self.dest_dir):
             os.mkdir(self.dest_dir)
         else:
-            print("[info: destination '{}' already exists]".format(self.dest_dir))
+            print("[info: destination '{0}' already exists]".format(self.dest_dir))
 
         if os.path.isdir(self.dest_spack):
-            print("[info: destination '{}' already exists]".format(self.dest_spack))
+            print("[info: destination '{0}' already exists]".format(self.dest_spack))
 
         self.pkg_src_dir = os.path.join(self.uberenv_path,self.pkg_src_dir)
         if not os.path.isdir(self.pkg_src_dir):
-            print("[ERROR: package_source_dir '{}' does not exist]".format(self.pkg_src_dir))
+            print("[ERROR: package_source_dir '{0}' does not exist]".format(self.pkg_src_dir))
             sys.exit(-1)
 
 
     def find_spack_pkg_path_from_hash(self, pkg_name, pkg_hash):
-        res, out = sexe("spack/bin/spack find -p /{}".format(pkg_hash), ret_output = True)
+        res, out = sexe("spack/bin/spack find -p /{0}".format(pkg_hash), ret_output = True)
         for l in out.split("\n"):
             if l.startswith(pkg_name):
                    return {"name": pkg_name, "path": l.split()[-1]}
-        print("[ERROR: failed to find package named '{}']".format(pkg_name))
+        print("[ERROR: failed to find package named '{0}']".format(pkg_name))
         sys.exit(-1)
 
     def find_spack_pkg_path(self, pkg_name, spec = ""):
@@ -447,7 +447,7 @@ class SpackEnv(UberEnv):
             # pick the first in the list.
             if l.startswith(pkg_name):
                    return {"name": pkg_name, "path": l.split()[-1]}
-        print("[ERROR: failed to find package named '{}']".format(pkg_name))
+        print("[ERROR: failed to find package named '{0}']".format(pkg_name))
         sys.exit(-1)
 
     # Extract the first line of the full spec
@@ -480,7 +480,7 @@ class SpackEnv(UberEnv):
             sha1 = self.project_opts["spack_commit"]
             res, current_sha1 = sexe("git log -1 --pretty=%H", ret_output=True)
             if sha1 != current_sha1:
-                print("[info: using spack commit {}]".format(sha1))
+                print("[info: using spack commit {0}]".format(sha1))
                 sexe("git stash", echo=True)
                 sexe("git fetch --depth=1 origin {0}".format(sha1),echo=True)
                 res = sexe("git checkout {0}".format(sha1),echo=True)
@@ -503,7 +503,7 @@ class SpackEnv(UberEnv):
         # disables all config scopes except "defaults", which we will
         # force our settings into
         spack_lib_config = pjoin(spack_dir,"lib","spack","spack","config.py")
-        print("[disabling config scope (except defaults) in: {}]".format(spack_lib_config))
+        print("[disabling config scope (except defaults) in: {0}]".format(spack_lib_config))
         cfg_script = open(spack_lib_config).read()
         for cfg_scope_stmt in ["('system', os.path.join(spack.paths.system_etc_path, 'spack')),",
                             "('site', os.path.join(spack.paths.etc_path, 'spack')),",
@@ -524,9 +524,9 @@ class SpackEnv(UberEnv):
 
         # copy in "defaults" config.yaml
         config_yaml = pabs(pjoin(cfg_dir,"..","config.yaml"))
-        sexe("cp {} {}/".format(config_yaml, spack_etc_defaults_dir), echo=True)
+        sexe("cp {0} {1}/".format(config_yaml, spack_etc_defaults_dir), echo=True)
         mirrors_yaml = pabs(pjoin(cfg_dir,"..","mirrors.yaml"))
-        sexe("cp {} {}/".format(mirrors_yaml, spack_etc_defaults_dir), echo=True)
+        sexe("cp {0} {1}/".format(mirrors_yaml, spack_etc_defaults_dir), echo=True)
 
         # copy in other settings per platform
         if not cfg_dir is None:
@@ -538,16 +538,16 @@ class SpackEnv(UberEnv):
             packages_yaml  = pjoin(cfg_dir,"packages.yaml")
 
             if os.path.isfile(config_yaml):
-                sexe("cp {} {}/".format(config_yaml , spack_etc_defaults_dir ), echo=True)
+                sexe("cp {0} {1}/".format(config_yaml , spack_etc_defaults_dir ), echo=True)
 
             if os.path.isfile(mirrors_yaml):
-                sexe("cp {} {}/".format(mirrors_yaml , spack_etc_defaults_dir ), echo=True)
+                sexe("cp {0} {1}/".format(mirrors_yaml , spack_etc_defaults_dir ), echo=True)
 
             if os.path.isfile(compilers_yaml):
-                sexe("cp {} {}/".format(compilers_yaml, spack_etc_defaults_dir ), echo=True)
+                sexe("cp {0} {1}/".format(compilers_yaml, spack_etc_defaults_dir ), echo=True)
 
             if os.path.isfile(packages_yaml):
-                sexe("cp {} {}/".format(packages_yaml, spack_etc_defaults_dir ), echo=True)
+                sexe("cp {0} {1}/".format(packages_yaml, spack_etc_defaults_dir ), echo=True)
         else:
             # let spack try to auto find compilers
             sexe("spack/bin/spack compiler find", echo=True)
@@ -600,7 +600,7 @@ class SpackEnv(UberEnv):
                     # testing that the path exists is mandatory until Spack team fixes
                     # https://github.com/spack/spack/issues/16329
                     if os.path.isdir(install_path):
-                        print("[Warning: {} {} has already been installed in {}]".format(self.pkg_name, self.opts["spec"],install_path))
+                        print("[Warning: {0} {1} has already been installed in {2}]".format(self.pkg_name, self.opts["spec"],install_path))
                         print("[Warning: Uberenv will proceed using this directory]".format(self.pkg_name))
                         self.use_install = True
 
@@ -615,9 +615,9 @@ class SpackEnv(UberEnv):
             if self.opts["ignore_ssl_errors"]:
                 install_cmd += "-k "
             if not self.opts["install"]:
-                install_cmd += "dev-build --quiet -d {} ".format(self.pkg_src_dir)
+                install_cmd += "dev-build --quiet -d {0} ".format(self.pkg_src_dir)
                 if self.pkg_final_phase:
-                    install_cmd += "-u {} ".format(self.pkg_final_phase)
+                    install_cmd += "-u {0} ".format(self.pkg_final_phase)
             else:
                 install_cmd += "install "
                 if self.opts["run_tests"]:
@@ -654,7 +654,7 @@ class SpackEnv(UberEnv):
         if self.opts["install"] or self.use_install:
             pkg_path = self.find_spack_pkg_path_from_hash(self.pkg_name, self.spec_hash)
             if self.pkg_name != pkg_path["name"]:
-                print("[ERROR: Could not find install of {}]".format(self.pkg_name))
+                print("[ERROR: Could not find install of {0}]".format(self.pkg_name))
                 return -1
             else:
                 # Symlink host-config file
@@ -665,24 +665,24 @@ class SpackEnv(UberEnv):
                     if os.path.islink(hc_fname):
                         os.unlink(hc_fname)
                     elif os.path.isfile(hc_fname):
-                        sexe("rm -f {}".format(hc_fname))
-                    print("[symlinking host config file to {}]".format(pjoin(self.dest_dir,hc_fname)))
+                        sexe("rm -f {0}".format(hc_fname))
+                    print("[symlinking host config file to {0}]".format(pjoin(self.dest_dir,hc_fname)))
                     os.symlink(hc_path,hc_fname)
 
                 # Symlink install directory
                 if self.opts["install"]:
-                    pkg_lnk_dir = "{}-install".format(self.pkg_name)
+                    pkg_lnk_dir = "{0}-install".format(self.pkg_name)
                     if os.path.islink(pkg_lnk_dir):
                         os.unlink(pkg_lnk_dir)
                     print("")
-                    print("[symlinking install to {}]".format(pjoin(self.dest_dir,pkg_lnk_dir)))
+                    print("[symlinking install to {0}]".format(pjoin(self.dest_dir,pkg_lnk_dir)))
                     os.symlink(pkg_path["path"],pabs(pkg_lnk_dir))
                     print("")
                     print("[install complete!]")
         # otherwise we are in the "only dependencies" case and the host-config
         # file has to be copied from the do-be-deleted spack-build dir.
         else:
-            pattern = "*{}.cmake".format(self.pkg_name)
+            pattern = "*{0}.cmake".format(self.pkg_name)
             build_dir = pjoin(self.pkg_src_dir,"spack-build")
             hc_glob = glob.glob(pjoin(build_dir,pattern))
             if len(hc_glob) > 0:
@@ -690,10 +690,10 @@ class SpackEnv(UberEnv):
                 hc_fname = os.path.split(hc_path)[1]
                 if os.path.islink(hc_fname):
                     os.unlink(hc_fname)
-                print("[copying host config file to {}]".format(pjoin(self.dest_dir,hc_fname)))
-                sexe("cp {} {}".format(hc_path,hc_fname))
-                print("[removing project build directory {}]".format(pjoin(build_dir)))
-                sexe("rm -rf {}".format(build_dir))
+                print("[copying host config file to {0}]".format(pjoin(self.dest_dir,hc_fname)))
+                sexe("cp {0} {1}".format(hc_path,hc_fname))
+                print("[removing project build directory {0}]".format(pjoin(build_dir)))
+                sexe("rm -rf {0}".format(build_dir))
 
     def get_mirror_path(self):
         mirror_path = self.opts["mirror"]
@@ -712,7 +712,7 @@ class SpackEnv(UberEnv):
         mirror_cmd = "spack/bin/spack "
         if self.opts["ignore_ssl_errors"]:
             mirror_cmd += "-k "
-        mirror_cmd += "mirror create -d {} --dependencies {}{}".format(mirror_path,
+        mirror_cmd += "mirror create -d {0} --dependencies {1}{2}".format(mirror_path,
                                                                     self.pkg_name,
                                                                     self.opts["spec"])
         return sexe(mirror_cmd, echo=True)
@@ -741,20 +741,20 @@ class SpackEnv(UberEnv):
 
         if existing_mirror_path and mirror_path != existing_mirror_path:
             # Existing mirror has different URL, error out
-            print("[removing existing spack mirror `{}` @ {}]".format(mirror_name,
+            print("[removing existing spack mirror `{0}` @ {1}]".format(mirror_name,
                                                                     existing_mirror_path))
             #
             # Note: In this case, spack says it removes the mirror, but we still
             # get errors when we try to add a new one, sounds like a bug
             #
-            sexe("spack/bin/spack mirror remove --scope=defaults {} ".format(mirror_name),
+            sexe("spack/bin/spack mirror remove --scope=defaults {0} ".format(mirror_name),
                 echo=True)
             existing_mirror_path = None
         if not existing_mirror_path:
             # Add if not already there
-            sexe("spack/bin/spack mirror add --scope=defaults {} {}".format(
+            sexe("spack/bin/spack mirror add --scope=defaults {0} {1}".format(
                     mirror_name, mirror_path), echo=True)
-            print("[using mirror {}]".format(mirror_path))
+            print("[using mirror {0}]".format(mirror_path))
 
     def find_spack_upstream(self, upstream_name):
         """
@@ -795,8 +795,8 @@ class SpackEnv(UberEnv):
             sexe("rm spack/etc/spack/defaults/upstreams.yaml")
             with open('spack/etc/spack/defaults/upstreams.yaml','w+') as upstreams_cfg_file:
                 upstreams_cfg_file.write("upstreams:\n")
-                upstreams_cfg_file.write("  {}:\n".format(upstream_name))
-                upstreams_cfg_file.write("    install_tree: {}\n".format(upstream_path))
+                upstreams_cfg_file.write("  {0}:\n".format(upstream_name))
+                upstreams_cfg_file.write("    install_tree: {0}\n".format(upstream_path))
 
 
 def find_osx_sdks():
@@ -836,8 +836,8 @@ def setup_osx_sdk_env_vars():
 
     env["MACOSX_DEPLOYMENT_TARGET"] = dep_tgt
     env["SDKROOT"] = sdk_root
-    print("[setting MACOSX_DEPLOYMENT_TARGET to {}]".format(env["MACOSX_DEPLOYMENT_TARGET"]))
-    print("[setting SDKROOT to {}]".format(env[ "SDKROOT"]))
+    print("[setting MACOSX_DEPLOYMENT_TARGET to {0}]".format(env["MACOSX_DEPLOYMENT_TARGET"]))
+    print("[setting SDKROOT to {0}]".format(env[ "SDKROOT"]))
 
 
 
@@ -903,3 +903,4 @@ def main():
 
 if __name__ == "__main__":
     sys.exit(main())
+

--- a/uberenv.py
+++ b/uberenv.py
@@ -106,6 +106,12 @@ def parse_args():
                       default=None,
                       help="spack compiler spec")
 
+    # for vcpkg, what architecture to target
+    parser.add_option("--triplet",
+                      dest="triplet",
+                      default=None,
+                      help="vcpkg architecture triplet")
+
     # optional location of spack mirror
     parser.add_option("--mirror",
                       dest="mirror",
@@ -164,12 +170,12 @@ def parse_args():
                       default=False,
                       help="Ignore SSL Errors")
 
-    # option to force a spack pull
+    # option to force a pull of the package manager
     parser.add_option("--pull",
                       action="store_true",
-                      dest="spack_pull",
+                      dest="repo_pull",
                       default=False,
-                      help="Pull if spack repo already exists")
+                      help="Pull from package manager, if repo already exists")
 
     # option to force for clean of packages specified to
     # be cleaned in the project.json
@@ -275,6 +281,9 @@ class UberEnv():
         # load project settings
         self.project_opts = load_json_file(opts["project_json"])
 
+        # setup main package name
+        self.pkg_name = self.set_from_args_or_json("package_name")
+
         # Set project.json defaults
         if not "force_commandline_prefix" in self.project_opts:
             self.project_opts["force_commandline_prefix"] = False
@@ -290,22 +299,25 @@ class UberEnv():
     def setup_paths_and_dirs(self):
         self.uberenv_path = uberenv_script_dir()
 
-    def set_from_args_or_json(self,setting):
-        try:
+
+    def set_from_args_or_json(self, setting, fail_on_undefined=True):
+        # Command line options take precedence over project file
+        setting_value = None
+        if setting in self.project_opts:
             setting_value = self.project_opts[setting]
-        except (KeyError):
-            print("ERROR: {0} must at least be defined in project.json".format(setting))
-            raise
-        else:
-            if self.opts[setting]:
-                setting_value = self.opts[setting]
+        if setting in self.opts:
+            setting_value = self.opts[setting]
+        if fail_on_undefined and setting_value == None:
+            print("ERROR: '{0}' must be defined in the project file or on the command line".format(setting))
+            sys.exit(-1)
+
         return setting_value
 
     def set_from_json(self,setting):
         try:
             setting_value = self.project_opts[setting]
         except (KeyError):
-            print("ERROR: {0} must at least be defined in project.json".format(setting))
+            print("ERROR: '{0}' must at least be defined in project.json".format(setting))
             raise
         return setting_value
 
@@ -320,15 +332,123 @@ class UberEnv():
         return res
 
 
+class VcpkgEnv(UberEnv):
+    """ Helper to clone vcpkg and install libraries on Windows """
+
+    def __init__(self, opts, extra_opts):
+        UberEnv.__init__(self,opts,extra_opts)
+
+        # setup architecture triplet
+        self.triplet = opts["triplet"]
+        if self.triplet is None:
+           self.triplet = os.getenv("VCPKG_DEFAULT_TRIPLET", "x86-windows")
+
+    def setup_paths_and_dirs(self):
+        # get the current working path, and the glob used to identify the
+        # package files we want to hot-copy to vcpkg
+
+        UberEnv.setup_paths_and_dirs(self)
+
+        self.ports = pjoin(self.uberenv_path, "vcpkg_ports","*")
+
+        # setup path for vcpkg repo
+        self.dest_vcpkg = pjoin(self.dest_dir,"vcpkg")
+
+        if os.path.isdir(self.dest_vcpkg):
+            print("[info: destination '{0}' already exists]".format(self.dest_vcpkg))
+
+    def clone_repo(self):
+        if not os.path.isdir(self.dest_vcpkg):
+            # compose clone command for the dest path, vcpkg url and branch
+            vcpkg_branch = self.project_opts.get("vcpkg_branch", "master")
+            vcpkg_url = self.project_opts.get("vcpkg_url", "https://github.com/microsoft/vcpkg")
+
+            print("[info: cloning vcpkg '{0}' branch from {1} into {2}]"
+                .format(vcpkg_branch,vcpkg_url, self.dest_vcpkg))
+
+            os.chdir(self.dest_dir)
+
+            clone_opts = ("-c http.sslVerify=false " 
+                          if self.opts["ignore_ssl_errors"] else "")
+
+            clone_cmd =  "git {0} clone -b {1} {2}".format(clone_opts, vcpkg_branch,vcpkg_url)
+            sexe(clone_cmd, echo=True)
+
+            # optionally, check out a specific commit
+            if "vcpkg_commit" in self.project_opts:
+                sha1 = self.project_opts["vcpkg_commit"]
+                print("[info: using vcpkg commit {0}]".format(sha1))
+                os.chdir(self.dest_vcpkg)
+                sexe("git checkout {0}".format(sha1),echo=True)
+                
+        if self.opts["repo_pull"]:
+            # do a pull to make sure we have the latest
+            os.chdir(self.dest_vcpkg)
+            sexe("git stash", echo=True)
+            sexe("git pull", echo=True)
+
+        # Bootstrap vcpkg
+        os.chdir(self.dest_vcpkg)
+        print("[info: bootstrapping vcpkg]")
+        sexe("bootstrap-vcpkg.bat -disableMetrics")
+
+    def patch(self):
+        """ hot-copy our ports into vcpkg """
+        
+        import distutils
+        from distutils import dir_util
+
+        src_vcpkg_ports = pjoin(self.uberenv_path, "vcpkg_ports")
+        dest_vcpkg_ports = pjoin(self.dest_vcpkg,"ports")
+
+        print("[info: copying from {0} to {1}]".format(src_vcpkg_ports,dest_vcpkg_ports))
+        distutils.dir_util.copy_tree(src_vcpkg_ports,dest_vcpkg_ports)
+
+
+    def clean_build(self):
+        pass
+
+    def show_info(self):
+        os.chdir(self.dest_vcpkg)
+        print("[info: Details for package '{0}']".format(self.pkg_name))
+        sexe("vcpkg.exe search " + self.pkg_name, echo=True)
+
+        print("[info: Dependencies for package '{0}']".format(self.pkg_name))
+        sexe("vcpkg.exe depend-info " + self.pkg_name, echo=True)
+
+    def create_mirror(self):
+        pass
+
+    def use_mirror(self):
+        pass
+
+    def install(self):
+        
+        os.chdir(self.dest_vcpkg)
+        install_cmd = "vcpkg.exe "
+        install_cmd += "install {0}:{1}".format(self.pkg_name, self.triplet)
+
+        res = sexe(install_cmd, echo=True)
+
+        # Running the install_cmd eventually generates the host config file,
+        # which we copy to the target directory.
+        src_hc = pjoin(self.dest_vcpkg, "installed", self.triplet, "include", self.pkg_name, "hc.cmake")
+        hcfg_fname = pjoin(self.dest_dir, "{0}.{1}.cmake".format(platform.uname()[1], self.triplet))
+        print("[info: copying host config file to {0}]".format(hcfg_fname))
+        shutil.copy(os.path.abspath(src_hc), hcfg_fname)
+        print("")
+        print("[install complete!]")
+        return res
+
+
 class SpackEnv(UberEnv):
     """ Helper to clone spack and install libraries on MacOS an Linux """
 
     def __init__(self, opts, extra_opts):
         UberEnv.__init__(self,opts,extra_opts)
 
-        self.pkg_name = self.set_from_args_or_json("package_name")
         self.pkg_version = self.set_from_json("package_version")
-        self.pkg_final_phase = self.set_from_args_or_json("package_final_phase")
+        self.pkg_final_phase = self.set_from_args_or_json("package_final_phase", False)
         self.pkg_src_dir = self.set_from_args_or_json("package_source_dir")
 
         self.packages_paths = []
@@ -489,7 +609,7 @@ class SpackEnv(UberEnv):
                     print("[ERROR: Git failed to checkout]")
                     sys.exit(-1)
 
-        if self.opts["spack_pull"]:
+        if self.opts["repo_pull"]:
             # do a pull to make sure we have the latest
             os.chdir(pjoin(self.dest_dir,"spack"))
             sexe("git stash", echo=True)
@@ -643,7 +763,9 @@ class SpackEnv(UberEnv):
                         break
                 if activate:
                     activate_cmd = "spack/bin/spack activate " + pkg_name
-                    sexe(activate_cmd, echo=True)
+                    res = sexe(activate_cmd, echo=True)
+                    if res != 0:
+                      return res
         # note: this assumes package extends python when +python
         # this may fail general cases
         if self.opts["install"] and "+python" in full_spec:
@@ -853,8 +975,8 @@ def main():
     # project options
     opts["project_json"] = find_project_config(opts)
 
-    # Initialize the environment
-    env = SpackEnv(opts, extra_opts)
+    # Initialize the environment -- use vcpkg on windows, spack otherwise
+    env = SpackEnv(opts, extra_opts) if not is_windows() else VcpkgEnv(opts, extra_opts)
 
     # Setup the necessary paths and directories
     env.setup_paths_and_dirs()

--- a/uberenv.py
+++ b/uberenv.py
@@ -47,7 +47,8 @@
 """
  file: uberenv.py
 
- description: automates using spack to install a project.
+ description: automates using a package manager to install a project.
+ Uses spack on Unix-based systems and Vcpkg on Windows-based systems.
 
 """
 
@@ -1000,16 +1001,16 @@ def main():
     env.show_info()
 
 
-    ##########################################################
-    # we now have an instance of spack configured how we
-    # need it to build our tpls at this point there are two
-    # possible next steps:
+    ###########################################################
+    # we now have an instance of our package manager configured
+    # how we need it to build our tpls. At this point there are
+    # two possible next steps:
     #
     # *) create a mirror of the packages
     #   OR
     # *) build
     #
-    ##########################################################
+    ###########################################################
     if opts["create_mirror"]:
         return env.create_mirror()
     else:

--- a/uberenv.py
+++ b/uberenv.py
@@ -300,18 +300,15 @@ class UberEnv():
     def setup_paths_and_dirs(self):
         self.uberenv_path = uberenv_script_dir()
 
-
-    def set_from_args_or_json(self, setting, fail_on_undefined=True):
-        # Command line options take precedence over project file
-        setting_value = None
-        if setting in self.project_opts:
+    def set_from_args_or_json(self,setting):
+        try:
             setting_value = self.project_opts[setting]
-        if setting in self.opts:
-            setting_value = self.opts[setting]
-        if fail_on_undefined and setting_value == None:
-            print("ERROR: '{0}' must be defined in the project file or on the command line".format(setting))
-            sys.exit(-1)
-
+        except (KeyError):
+            print("ERROR: '{0}' must at least be defined in project.json".format(setting))
+            raise
+        else:
+            if self.opts[setting]:
+                setting_value = self.opts[setting]
         return setting_value
 
     def set_from_json(self,setting):
@@ -340,7 +337,7 @@ class VcpkgEnv(UberEnv):
         UberEnv.__init__(self,opts,extra_opts)
 
         # setup architecture triplet
-        self.vcpkg_triplet = self.set_from_args_or_json("vcpkg_triplet", False)
+        self.vcpkg_triplet = self.set_from_args_or_json("vcpkg_triplet")
         print("Vcpkg triplet: {}".format(self.vcpkg_triplet))
         if self.vcpkg_triplet is None:
            self.vcpkg_triplet = os.getenv("VCPKG_DEFAULT_TRIPLET", "x86-windows")
@@ -450,7 +447,7 @@ class SpackEnv(UberEnv):
         UberEnv.__init__(self,opts,extra_opts)
 
         self.pkg_version = self.set_from_json("package_version")
-        self.pkg_final_phase = self.set_from_args_or_json("package_final_phase", False)
+        self.pkg_final_phase = self.set_from_args_or_json("package_final_phase")
         self.pkg_src_dir = self.set_from_args_or_json("package_source_dir")
 
         self.packages_paths = []

--- a/uberenv.py
+++ b/uberenv.py
@@ -300,6 +300,23 @@ class UberEnv():
     def setup_paths_and_dirs(self):
         self.uberenv_path = uberenv_script_dir()
 
+        # setup destination paths
+        if not self.opts["prefix"]:
+            if self.project_opts["force_commandline_prefix"]:
+                # project has specified prefix must be on command line
+                print("[ERROR: --prefix flag for library destination is required]")
+                sys.exit(1)
+            # otherwise set default
+            self.opts["prefix"] = "uberenv_libs"
+
+        self.dest_dir = pabs(self.opts["prefix"])
+
+        # print a warning if the dest path already exists
+        if not os.path.isdir(self.dest_dir):
+            os.mkdir(self.dest_dir)
+        else:
+            print("[info: destination '{0}' already exists]".format(self.dest_dir))
+
     def set_from_args_or_json(self,setting):
         try:
             setting_value = self.project_opts[setting]
@@ -351,6 +368,7 @@ class VcpkgEnv(UberEnv):
         self.ports = pjoin(self.uberenv_path, "vcpkg_ports","*")
 
         # setup path for vcpkg repo
+        print("[installing to: {0}]".format(self.dest_dir))
         self.dest_vcpkg = pjoin(self.dest_dir,"vcpkg")
 
         if os.path.isdir(self.dest_vcpkg):
@@ -523,25 +541,9 @@ class SpackEnv(UberEnv):
             # default to packages living next to uberenv script if it exists
             self.append_path_to_packages_paths(pjoin(self.uberenv_path,"packages"), errorOnNonexistant=False)
 
-        # setup destination paths
-        if not self.opts["prefix"]:
-            if self.project_opts["force_commandline_prefix"]:
-                # project has specified prefix must be on command line
-                print("[ERROR: --prefix flag for library destination is required]")
-                sys.exit(1)
-            # otherwise set default
-            self.opts["prefix"] = "uberenv_libs"
-            
-        self.dest_dir = pabs(self.opts["prefix"])
-        self.dest_spack = pjoin(self.dest_dir,"spack")
         print("[installing to: {0}]".format(self.dest_dir))
 
-        # print a warning if the dest path already exists
-        if not os.path.isdir(self.dest_dir):
-            os.mkdir(self.dest_dir)
-        else:
-            print("[info: destination '{0}' already exists]".format(self.dest_dir))
-
+        self.dest_spack = pjoin(self.dest_dir,"spack")
         if os.path.isdir(self.dest_spack):
             print("[info: destination '{0}' already exists]".format(self.dest_spack))
 


### PR DESCRIPTION
This is a second attempt at adding support for Vcpkg to uberenv as a package manager for Windows.  The previous PR (#22) was very out of date, so I created a new branch and PR for this work, and will close that one.

### Details
* I think I've addressed all the concerns raised in #22, but please check that I didn't miss anything important.
* I've tested this update against Axom's develop branch on Windows, where it successfully built `mfem`, `hdf5` and `conduit`. 
  * There was an unrelated problem building `inlet`, so I had to set `AXOM_ENABLE_INLET=OFF`. I'll create an issue on Axom to address this, but it should not hold up the current PR. I think the issue was related to `c++11` vs. `c++14`.
* I'm am currently testing this against Axom's `develop` branch on LC, so there might be some slight adjustments
   * **UPDATE:** This branch's `uberenv` successfully built all of Axom's TPLs on LC
* I had trouble building Axom's TPLs on WSL with this version of uberenv. It is possible that it will now need a customized `spack_configs` directory to support this. I can create an issue (here or in Axom) to address this, if there is interest
