### PR TITLE
2021-01 cyrush workarounds and tweaks

### DIFF
--- a/uberenv.py
+++ b/uberenv.py
@@ -764,7 +764,7 @@ class SpackEnv(UberEnv):
     def show_info(self):
         # print concretized spec
         # show short spec first
-        spec_cmd = "spack/bin/spack spec {1}{2}".format(self.pkg_name,self.opts["spec"])
+        spec_cmd = "spack/bin/spack spec {0}{1}".format(self.pkg_name,self.opts["spec"])
         res, out = sexe(spec_cmd, ret_output=True, echo=True)
         print(out)
         # now show detailed spec with install info

--- a/uberenv.py
+++ b/uberenv.py
@@ -756,6 +756,7 @@ class SpackEnv(UberEnv):
             if not self.opts["install"]:
                 # create dest dir for dev build
                 build_base = pjoin(self.dest_dir,"{0}-build".format(self.pkg_name))
+                print("[spack dev build working directory: {0}]".format(build_base))
                 build_dir  = pjoin(build_base,"spack-build")
                 if not os.path.isdir(build_base):
                     os.mkdir(build_base)
@@ -763,7 +764,7 @@ class SpackEnv(UberEnv):
                     os.mkdir(build_dir)
                 # symlink self.pkg_src_dir into dest dir as spack-src
                 os.symlink(self.pkg_src_dir,pjoin(build_base,"spack-src"))
-                install_cmd += "dev-build --quiet -d {0} ".format(self.build_dir)
+                install_cmd += "dev-build --quiet -d {0} ".format(build_dir)
                 if self.pkg_final_phase:
                     install_cmd += "-u {0} ".format(self.pkg_final_phase)
             else:
@@ -838,8 +839,10 @@ class SpackEnv(UberEnv):
         # THIS SHOULD BE CHANGED TO COPY FROM `self.pkg_src_dir`
         # -------
         else:
+            build_base = pjoin(self.dest_dir,"{0}-build".format(self.pkg_name))
+            build_dir  = pjoin(build_base,"spack-build")
             pattern = "*{0}.cmake".format(self.pkg_name)
-            build_dir = pjoin(self.pkg_src_dir,"spack-build")
+            #build_dir = pjoin(self.pkg_src_dir,"spack-build")
             hc_glob = glob.glob(pjoin(build_dir,pattern))
             if len(hc_glob) > 0:
                 hc_path  = hc_glob[0]

--- a/uberenv.py
+++ b/uberenv.py
@@ -514,7 +514,6 @@ class SpackEnv(UberEnv):
 
     def __init__(self, opts, extra_opts):
         UberEnv.__init__(self,opts,extra_opts)
-
         self.pkg_version = self.set_from_json("package_version")
         self.pkg_src_dir = self.set_from_args_or_json("package_source_dir")
         self.pkg_final_phase = self.set_from_args_or_json("package_final_phase",True)
@@ -551,6 +550,13 @@ class SpackEnv(UberEnv):
 
         print("[spack spec: {0}]".format(self.opts["spec"]))
 
+    def print_spack_python_info(self):
+        spack_dir = self.dest_spack
+        cmd = pjoin(spack_dir,"bin","spack")
+        cmd += " python "
+        cmd += '-c "import sys; print(sys.executable);"'
+        res, out = sexe( cmd, ret_output = True)
+        print("[spack python: {0}]".format(out.strip()))
 
     def append_path_to_packages_paths(self, path, errorOnNonexistant=True):
         path = pabs(path)
@@ -706,6 +712,9 @@ class SpackEnv(UberEnv):
 
         cfg_dir = self.spack_config_dir
         spack_dir = self.dest_spack
+
+        # this is an opportunity to show spack python info post obtaining spack
+        self.print_spack_python_info()
 
         # force spack to use only "defaults" config scope
         self.disable_spack_config_scopes(spack_dir)
@@ -1058,12 +1067,17 @@ def setup_osx_sdk_env_vars():
     print("[setting SDKROOT to {0}]".format(env[ "SDKROOT"]))
 
 
+def print_uberenv_python_info():
+    print("[uberenv python: {0}]".format(sys.executable))
+
 
 def main():
     """
     Clones and runs a package manager to setup third_party libs.
     Also creates a host-config.cmake file that can be used by our project.
     """
+
+    print_uberenv_python_info()
 
     # parse args from command line
     opts, extra_opts = parse_args()

--- a/uberenv.py
+++ b/uberenv.py
@@ -561,8 +561,9 @@ class SpackEnv(UberEnv):
         # -------
         self.pkg_src_dir = os.path.join(self.dest_dir,self.pkg_src_dir)
         if not os.path.isdir(self.pkg_src_dir):
-            print("[ERROR: package_source_dir '{0}' does not exist]".format(self.pkg_src_dir))
-            sys.exit(-1)
+            os.mkdir(self.pkg_src_dir)
+            #print("[ERROR: package_source_dir '{0}' does not exist]".format(self.pkg_src_dir))
+            #sys.exit(-1)
 
 
     def find_spack_pkg_path_from_hash(self, pkg_name, pkg_hash):

--- a/uberenv.py
+++ b/uberenv.py
@@ -350,9 +350,8 @@ class UberEnv():
             if not optional:
                 print("ERROR: '{0}' must at least be defined in project.json".format(setting))
                 raise
-        else:
-            if self.opts[setting]:
-                setting_value = self.opts[setting]
+        if self.opts[setting]:
+            setting_value = self.opts[setting]
         return setting_value
 
     def set_from_json(self,setting, optional=True):

--- a/uberenv.py
+++ b/uberenv.py
@@ -768,7 +768,7 @@ class SpackEnv(UberEnv):
                 # The spack looks for this env var, if present
                 # uses it to select the destination. 
                 os.environ["UBERENV_HOSTCONFIG_DEST_DIR"] = self.dest_dir
-                install_cmd += "dev-build -d {0} ".format(self.pkg_src_dir)
+                install_cmd += "dev-build --quiet -d {0} ".format(self.pkg_src_dir)
                 if self.opts["build_jobs"]:
                     install_cmd += "-j {0}".format(self.opts["build_jobs"])
                 if self.pkg_final_phase:

--- a/uberenv.py
+++ b/uberenv.py
@@ -555,7 +555,11 @@ class SpackEnv(UberEnv):
         if os.path.isdir(self.dest_spack):
             print("[info: destination '{0}' already exists]".format(self.dest_spack))
 
-        self.pkg_src_dir = os.path.join(self.uberenv_path,self.pkg_src_dir)
+        # -------
+        # dev-build is only used for the non install case (he hostconfig case)
+        # can we set build dir relative to to dest?
+        # -------
+        self.pkg_src_dir = os.path.join(self.dest_dir,self.pkg_src_dir)
         if not os.path.isdir(self.pkg_src_dir):
             print("[ERROR: package_source_dir '{0}' does not exist]".format(self.pkg_src_dir))
             sys.exit(-1)
@@ -814,6 +818,10 @@ class SpackEnv(UberEnv):
                     print("[install complete!]")
         # otherwise we are in the "only dependencies" case and the host-config
         # file has to be copied from the do-be-deleted spack-build dir.
+        # -------
+        # NOTE: USING DEV BUILD, there is no `spack-build` dir
+        # THIS SHOULD BE CHANGED TO COPY FROM `self.pkg_src_dir`
+        # -------
         else:
             pattern = "*{0}.cmake".format(self.pkg_name)
             build_dir = pjoin(self.pkg_src_dir,"spack-build")

--- a/uberenv.py
+++ b/uberenv.py
@@ -755,7 +755,7 @@ class SpackEnv(UberEnv):
                 install_cmd += "-k "
             if not self.opts["install"]:
                 # create dest dir for dev build
-                build_base = pjoin(self.dest_dir,"{0}-build".format(pkg_name))
+                build_base = pjoin(self.dest_dir,"{0}-build".format(self.pkg_name))
                 build_dir  = pjoin(build_base,"spack-build")
                 if not os.path.isdir(build_base):
                     os.mkdir(build_base)

--- a/uberenv.py
+++ b/uberenv.py
@@ -151,13 +151,13 @@ def parse_args():
                       default=None,
                       help="override the default package name")
 
-    # uberenv tpl build mode
-    parser.add_option("--build-mode",
-                      dest="build_mode",
+    # uberenv spack tpl build mode
+    parser.add_option("--spack-build-mode",
+                      dest="spack_build_mode",
                       default=None,
-                      help="set mode used to build third party dependencies "
-                           "(spack options: 'dev-build' 'uberenv-pkg' 'install' "
-                           "[spack default: 'dev-build'] )\n")
+                      help="set mode used to build third party dependencies with spack"
+                           "(options: 'dev-build' 'uberenv-pkg' 'install' "
+                           "[default: 'dev-build'] )\n")
 
     # controls after which package phase spack should stop
     parser.add_option("--package-final-phase",
@@ -527,7 +527,7 @@ class SpackEnv(UberEnv):
         self.pkg_src_dir = self.set_from_args_or_json("package_source_dir")
         self.pkg_final_phase = self.set_from_args_or_json("package_final_phase",True)
         # get build mode
-        self.build_mode = self.set_from_args_or_json("build_mode",True)
+        self.build_mode = self.set_from_args_or_json("spack_build_mode",True)
         # default spack build mode is dev-build
         if self.build_mode is None:
             self.build_mode = "dev-build"
@@ -911,6 +911,8 @@ class SpackEnv(UberEnv):
                     print("[install complete!]")
         else:
             if self.build_mode == "dev-build":
+                # we are in the "only dependencies" dev build case and the host-config
+                # file has to be copied from the do-be-deleted spack-build dir.
                 build_base = pjoin(self.dest_dir,"{0}-build".format(self.pkg_name))
                 build_dir  = pjoin(build_base,"spack-build")
                 pattern = "*{0}.cmake".format(self.pkg_name)

--- a/uberenv.py
+++ b/uberenv.py
@@ -762,16 +762,9 @@ class SpackEnv(UberEnv):
                         res = sexe(unist_cmd, echo=True)
 
     def show_info(self):
-        # print concretized spec
-        # show short spec first
-        spec_cmd = "spack/bin/spack spec {0}{1}".format(self.pkg_name,self.opts["spec"])
-        res, out = sexe(spec_cmd, ret_output=True, echo=True)
-        print(out)
-        # now show detailed spec with install info
+        # print concretized spec with install info
         # default case prints install status and 32 characters hash
         options="--install-status --very-long"
-        #if not self.project_opts["spack_spec_print_options"] is None:
-        #    options = self.project_opts["spack_spec_print_options"]
         spec_cmd = "spack/bin/spack spec {0} {1}{2}".format(options,self.pkg_name,self.opts["spec"])
 
         res, out = sexe(spec_cmd, ret_output=True, echo=True)

--- a/uberenv.py
+++ b/uberenv.py
@@ -150,11 +150,6 @@ def parse_args():
                       dest="package_name",
                       default=None,
                       help="override the default package name")
-    # overrides uberenv_package_name
-    parser.add_option("--uberenv-package-name",
-                      dest="uberenv_package_name",
-                      default=None,
-                      help="override the default uberenv package name")
 
     # controls after which package phase spack should stop
     parser.add_option("--package-final-phase",
@@ -354,12 +349,21 @@ class UberEnv():
                 setting_value = self.opts[setting]
         return setting_value
 
-    def set_from_json(self,setting):
+    def set_from_json(self,setting, optional=True):
+        """
+        When optional=False: 
+            If the setting key is not in the json file, error and raise an exception.
+        When optional=True:
+            If the setting key is not in the json file or opts, return None.
+        """
         try:
             setting_value = self.project_opts[setting]
         except (KeyError):
-            print("ERROR: '{0}' must at least be defined in project.json".format(setting))
-            raise
+            if not optional:
+                print("ERROR: '{0}' must at least be defined in project.json".format(setting))
+                raise
+            else:
+                return None
         return setting_value
 
     def detect_platform(self):
@@ -519,7 +523,7 @@ class SpackEnv(UberEnv):
         self.pkg_final_phase = self.set_from_args_or_json("package_final_phase",True)
         self.use_dev_build = True
         # check if we are using uberenv package to build tpls
-        self.uberenv_package_name = self.set_from_args_or_json("uberenv_package_name",True)
+        self.uberenv_package_name = self.set_from_json("uberenv_package_name",True)
         if not self.opts["install"] and self.uberenv_package_name:
             self.use_dev_build = False
             self.pkg_name = self.uberenv_package_name

--- a/uberenv.py
+++ b/uberenv.py
@@ -156,7 +156,8 @@ def parse_args():
                       dest="build_mode",
                       default=None,
                       help="set mode used to build third party dependencies "
-                           "(spack options: 'dev-build' 'uberenv-pkg')")
+                           "(spack options: 'dev-build' 'uberenv-pkg' 'install' "
+                           "[spack default: 'dev-build'] )\n")
 
     # controls after which package phase spack should stop
     parser.add_option("--package-final-phase",
@@ -525,8 +526,9 @@ class SpackEnv(UberEnv):
         self.pkg_version = self.set_from_json("package_version")
         self.pkg_src_dir = self.set_from_args_or_json("package_source_dir")
         self.pkg_final_phase = self.set_from_args_or_json("package_final_phase",True)
-        # check if we are using uberenv package to build tpls
+        # get build mode
         self.build_mode = self.set_from_args_or_json("build_mode",True)
+        # default spack build mode is dev-build
         if self.build_mode is None:
             self.build_mode = "dev-build"
         # NOTE: install always overrides the build mode to "install"


### PR DESCRIPTION
This branch includes:

1) A workaround to get back to point where the host config is generated in the prefix dir (#44)
2) Addition of a `-j` option to control build jobs (override what is presented in configs for more control)
3) Addition of a json file option to control (#45)

WIP.
I don't expect us to merge as is. Need a better solution for #44, we should discuss. 

Note: I am using this branch to allow me to move forward with updating uberenv for conduit. 
