### PR TITLE
Add an option to select Spack's new concretizer

### DIFF
--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -181,25 +181,25 @@ is found in the in the following order:
 
 Project settings are as follows:
 
- ========================== ========================== ================================================ =======================================
-  Setting                   Command line Option        Description                                      Default
- ========================== ========================== ================================================ =======================================
-  package_name              ``--package-name``         Spack package name                               **None**
-  package_version           **None**                   Spack package version                            **None**
-  package_final_phase       ``--package-final-phase``  Controls after which phase Spack should stop     **None**
-  package_source_dir        ``--package-source-dir``   Controls the source directory Spack should use   **None**
-  force_commandline_prefix  **None**                   Force user to specify `--prefix` on command line ``False``
-  spack_url                 **None**                   Download url for Spack                           ``https://github.com/spack/spack.git``
-  spack_commit              **None**                   Spack commit to checkout                         **None**
-  spack_activate            **None**                   Spack packages to activate                       **None**
-  spack_configs_path        **None**                   Directory with Spack configs to be copied        ``spack_configs``
-  spack_packages_path       **None**                   Directory with Spack packages to be copied       ``packages``
-  vcpkg_url                 **None**                   Download url for Vcpkg                           ``https://github.com/microsoft/vcpkg``
-  vcpkg_branch              **None**                   Vcpkg branch to checkout                         ``master``
-  vcpkg_commit              **None**                   Vcpkg commit to checkout                         **None**
-  vcpkg_ports_path          ``--vcpkg-ports-path``     Folder with vcpkg ports files                    **None**
-  spack_use_new_concretizer **None**                   Use Spack's ASP solver for concretization        ``False``
- ========================== ========================== ================================================ =======================================
+ ========================= ========================== ================================================ =======================================
+  Setting                  Command line Option        Description                                      Default
+ ========================= ========================== ================================================ =======================================
+  package_name             ``--package-name``         Spack package name                               **None**
+  package_version          **None**                   Spack package version                            **None**
+  package_final_phase      ``--package-final-phase``  Controls after which phase Spack should stop     **None**
+  package_source_dir       ``--package-source-dir``   Controls the source directory Spack should use   **None**
+  force_commandline_prefix **None**                   Force user to specify `--prefix` on command line ``False``
+  spack_url                **None**                   Download url for Spack                           ``https://github.com/spack/spack.git``
+  spack_commit             **None**                   Spack commit to checkout                         **None**
+  spack_activate           **None**                   Spack packages to activate                       **None**
+  spack_configs_path       **None**                   Directory with Spack configs to be copied        ``spack_configs``
+  spack_packages_path      **None**                   Directory with Spack packages to be copied       ``packages``
+  spack_concretizer        **None**                   Spack concretizer to use ``original, clingo``    ``original``
+  vcpkg_url                **None**                   Download url for Vcpkg                           ``https://github.com/microsoft/vcpkg``
+  vcpkg_branch             **None**                   Vcpkg branch to checkout                         ``master``
+  vcpkg_commit             **None**                   Vcpkg commit to checkout                         **None**
+  vcpkg_ports_path         ``--vcpkg-ports-path``     Folder with vcpkg ports files                    **None**
+ ========================= ========================== ================================================ =======================================
 
 If a ``spack_commit`` is present, it supercedes the ``spack_branch`` option, and similarly for ``vcpkg_commit`` and ``vcpkg_branch``.
 

--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -198,6 +198,7 @@ Project settings are as follows:
   vcpkg_branch             **None**                   Vcpkg branch to checkout                         ``master``
   vcpkg_commit             **None**                   Vcpkg commit to checkout                         **None**
   vcpkg_ports_path         ``--vcpkg-ports-path``     Folder with vcpkg ports files                    **None**
+  use_clingo               **None**                   Use Spack's ASP solver for concretization        ``False``
  ========================= ========================== ================================================ =======================================
 
 If a ``spack_commit`` is present, it supercedes the ``spack_branch`` option, and similarly for ``vcpkg_commit`` and ``vcpkg_branch``.

--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -181,25 +181,25 @@ is found in the in the following order:
 
 Project settings are as follows:
 
- ========================= ========================== ================================================ =======================================
-  Setting                  Command line Option        Description                                      Default
- ========================= ========================== ================================================ =======================================
-  package_name             ``--package-name``         Spack package name                               **None**
-  package_version          **None**                   Spack package version                            **None**
-  package_final_phase      ``--package-final-phase``  Controls after which phase Spack should stop     **None**
-  package_source_dir       ``--package-source-dir``   Controls the source directory Spack should use   **None**
-  force_commandline_prefix **None**                   Force user to specify `--prefix` on command line ``False``
-  spack_url                **None**                   Download url for Spack                           ``https://github.com/spack/spack.git``
-  spack_commit             **None**                   Spack commit to checkout                         **None**
-  spack_activate           **None**                   Spack packages to activate                       **None**
-  spack_configs_path       **None**                   Directory with Spack configs to be copied        ``spack_configs``
-  spack_packages_path      **None**                   Directory with Spack packages to be copied       ``packages``
-  vcpkg_url                **None**                   Download url for Vcpkg                           ``https://github.com/microsoft/vcpkg``
-  vcpkg_branch             **None**                   Vcpkg branch to checkout                         ``master``
-  vcpkg_commit             **None**                   Vcpkg commit to checkout                         **None**
-  vcpkg_ports_path         ``--vcpkg-ports-path``     Folder with vcpkg ports files                    **None**
-  use_clingo               **None**                   Use Spack's ASP solver for concretization        ``False``
- ========================= ========================== ================================================ =======================================
+ ========================== ========================== ================================================ =======================================
+  Setting                   Command line Option        Description                                      Default
+ ========================== ========================== ================================================ =======================================
+  package_name              ``--package-name``         Spack package name                               **None**
+  package_version           **None**                   Spack package version                            **None**
+  package_final_phase       ``--package-final-phase``  Controls after which phase Spack should stop     **None**
+  package_source_dir        ``--package-source-dir``   Controls the source directory Spack should use   **None**
+  force_commandline_prefix  **None**                   Force user to specify `--prefix` on command line ``False``
+  spack_url                 **None**                   Download url for Spack                           ``https://github.com/spack/spack.git``
+  spack_commit              **None**                   Spack commit to checkout                         **None**
+  spack_activate            **None**                   Spack packages to activate                       **None**
+  spack_configs_path        **None**                   Directory with Spack configs to be copied        ``spack_configs``
+  spack_packages_path       **None**                   Directory with Spack packages to be copied       ``packages``
+  vcpkg_url                 **None**                   Download url for Vcpkg                           ``https://github.com/microsoft/vcpkg``
+  vcpkg_branch              **None**                   Vcpkg branch to checkout                         ``master``
+  vcpkg_commit              **None**                   Vcpkg commit to checkout                         **None**
+  vcpkg_ports_path          ``--vcpkg-ports-path``     Folder with vcpkg ports files                    **None**
+  spack_use_new_concretizer **None**                   Use Spack's ASP solver for concretization        ``False``
+ ========================== ========================== ================================================ =======================================
 
 If a ``spack_commit`` is present, it supercedes the ``spack_branch`` option, and similarly for ``vcpkg_commit`` and ``vcpkg_branch``.
 

--- a/uberenv.py
+++ b/uberenv.py
@@ -1072,7 +1072,7 @@ class SpackEnv(UberEnv):
                 sys.exit(1)
             py_interp = sys.executable
             clingo_pkg = "clingo-cffi-wheel"
-            uninstall_cmd = "{0} -m pip uninstall {1}".format(py_interp, clingo_pkg)
+            uninstall_cmd = "{0} -m pip uninstall -y {1}".format(py_interp, clingo_pkg)
             # Uninstall it first in case the available version failed due to differing arch
             # pip will still return 0 in the case of a "trivial" uninstall
             res = sexe(uninstall_cmd, echo=True)

--- a/uberenv.py
+++ b/uberenv.py
@@ -1057,32 +1057,13 @@ class SpackEnv(UberEnv):
         """
         try:
             import clingo
-        except ModuleNotFoundError:
-            import pip
-            pip_ver = pip.__version__
-            # Requirement comes from https://github.com/pypa/manylinux
-            # JBE: I think the string comparison is somewhat correct here, if not we'll
-            # need to install setuptools for 'packaging.version'
-            if pip_ver < "19.3":
-                print("[ERROR: pip version {0} is too old to install clingo".format(pip_ver))
-                print("  pip 19.3 is required for PEP 599 support")
-                print("]")
-                sys.exit(1)
-            py_interp = sys.executable
-            clingo_pkg = "clingo"
-            uninstall_cmd = "{0} -m pip uninstall -y {1}".format(py_interp, clingo_pkg)
-            # Uninstall it first in case the available version failed due to differing arch
-            # pip will still return 0 in the case of a "trivial" uninstall
-            res = sexe(uninstall_cmd, echo=True)
-            if res != 0:
-                print("[ERROR: clingo uninstall failed with returncode {0}]".format(res))
-                sys.exit(1)
+        except ImportError:
             install_cmd = "{0} -m pip install --user {1}".format(py_interp, clingo_pkg)
-            res = sexe(install_cmd, echo=True)
-            if res != 0:
-                print("[ERROR: clingo install failed with returncode {0}]".format(res))
-                sys.exit(1)
-
+            print("[ERROR: clingo module not installed, run the following:")
+            print("  {0}".format(install_cmd))
+            print("  Requires pip >= 19.3")
+            print("]")
+            sys.exit(1)
 
 def find_osx_sdks():
     """

--- a/uberenv.py
+++ b/uberenv.py
@@ -1071,7 +1071,7 @@ class SpackEnv(UberEnv):
                 print("]")
                 sys.exit(1)
             py_interp = sys.executable
-            clingo_pkg = "clingo-cffi-wheel"
+            clingo_pkg = "clingo"
             uninstall_cmd = "{0} -m pip uninstall -y {1}".format(py_interp, clingo_pkg)
             # Uninstall it first in case the available version failed due to differing arch
             # pip will still return 0 in the case of a "trivial" uninstall
@@ -1079,10 +1079,7 @@ class SpackEnv(UberEnv):
             if res != 0:
                 print("[ERROR: clingo uninstall failed with returncode {0}]".format(res))
                 sys.exit(1)
-            # This repo is from https://github.com/joshessman-llnl/package-clingo-manylinux
-            # According to https://github.com/potassco/clingo/pull/255 "official" releases
-            # will have PPC builds, so switch over once Clingo releases 5.4.2
-            install_cmd = "{0} -m pip install --user -i https://test.pypi.org/simple/ {1}".format(py_interp, clingo_pkg)
+            install_cmd = "{0} -m pip install --user {1}".format(py_interp, clingo_pkg)
             res = sexe(install_cmd, echo=True)
             if res != 0:
                 print("[ERROR: clingo install failed with returncode {0}]".format(res))

--- a/uberenv.py
+++ b/uberenv.py
@@ -544,7 +544,7 @@ class SpackEnv(UberEnv):
         self.spec_hash = ""
         self.use_install = False
   
-        if "use_clingo" in self.project_opts and self.project_opts["use_clingo"]:
+        if "spack_use_new_concretizer" in self.project_opts and self.project_opts["spack_use_new_concretizer"]:
             self.use_clingo = True
             self.setup_clingo()
         else:

--- a/uberenv.py
+++ b/uberenv.py
@@ -1057,13 +1057,32 @@ class SpackEnv(UberEnv):
         """
         try:
             import clingo
-        except ImportError:
+        except ModuleNotFoundError:
+            import pip
+            pip_ver = pip.__version__
+            # Requirement comes from https://github.com/pypa/manylinux
+            # JBE: I think the string comparison is somewhat correct here, if not we'll
+            # need to install setuptools for 'packaging.version'
+            if pip_ver < "19.3":
+                print("[ERROR: pip version {0} is too old to install clingo".format(pip_ver))
+                print("  pip 19.3 is required for PEP 599 support")
+                print("]")
+                sys.exit(1)
+            py_interp = sys.executable
+            clingo_pkg = "clingo"
+            uninstall_cmd = "{0} -m pip uninstall -y {1}".format(py_interp, clingo_pkg)
+            # Uninstall it first in case the available version failed due to differing arch
+            # pip will still return 0 in the case of a "trivial" uninstall
+            res = sexe(uninstall_cmd, echo=True)
+            if res != 0:
+                print("[ERROR: clingo uninstall failed with returncode {0}]".format(res))
+                sys.exit(1)
             install_cmd = "{0} -m pip install --user {1}".format(py_interp, clingo_pkg)
-            print("[ERROR: clingo module not installed, run the following:")
-            print("  {0}".format(install_cmd))
-            print("  Requires pip >= 19.3")
-            print("]")
-            sys.exit(1)
+            res = sexe(install_cmd, echo=True)
+            if res != 0:
+                print("[ERROR: clingo install failed with returncode {0}]".format(res))
+                sys.exit(1)
+
 
 def find_osx_sdks():
     """

--- a/uberenv.py
+++ b/uberenv.py
@@ -543,7 +543,7 @@ class SpackEnv(UberEnv):
         self.spec_hash = ""
         self.use_install = False
   
-        if "spack_use_new_concretizer" in self.project_opts and self.project_opts["spack_use_new_concretizer"]:
+        if "spack_concretizer" in self.project_opts and self.project_opts["spack_concretizer"] == "clingo":
             self.use_clingo = True
             self.setup_clingo()
         else:

--- a/uberenv.py
+++ b/uberenv.py
@@ -779,14 +779,11 @@ class SpackEnv(UberEnv):
 
         # Update spack's config.yaml if clingo was requested
         if self.use_clingo:
-            import yaml
-            with open(pjoin(spack_etc_defaults_dir, "config.yaml"), 'r') as conf_file:
-                conf_data = conf_file.read()
-            conf_yaml = yaml.load(conf_data)
-            conf_yaml['config']['concretizer'] = 'clingo'
-            # This will leave out all the comments, is this a problem?
-            with open(pjoin(spack_etc_defaults_dir, "config.yaml"), 'w') as conf_file:
-                conf_file.write(yaml.dump(conf_yaml))
+            concretizer_cmd = "spack/bin/spack config --scope defaults add config:concretizer:clingo"
+            res = sexe(concretizer_cmd, echo=True)
+            if res != 0:
+                print("[ERROR: Failed to update spack configuration to use new concretizer]")
+                sys.exit(-1)
 
 
 

--- a/uberenv.py
+++ b/uberenv.py
@@ -524,7 +524,7 @@ class SpackEnv(UberEnv):
     def __init__(self, opts, extra_opts):
         UberEnv.__init__(self,opts,extra_opts)
         self.pkg_version = self.set_from_json("package_version")
-        self.pkg_src_dir = self.set_from_args_or_json("package_source_dir")
+        self.pkg_src_dir = self.set_from_args_or_json("package_source_dir", True)
         self.pkg_final_phase = self.set_from_args_or_json("package_final_phase",True)
         # get build mode
         self.build_mode = self.set_from_args_or_json("spack_build_mode",True)
@@ -640,10 +640,11 @@ class SpackEnv(UberEnv):
         if os.path.isdir(self.dest_spack):
             print("[info: destination '{0}' already exists]".format(self.dest_spack))
 
-        self.pkg_src_dir = os.path.abspath(os.path.join(self.dest_dir,self.pkg_src_dir))
-        if not os.path.isdir(self.pkg_src_dir):
-            print("[ERROR: package_source_dir '{0}' does not exist]".format(self.pkg_src_dir))
-            sys.exit(-1)
+        if self.build_mode == "dev-build":
+            self.pkg_src_dir = os.path.abspath(os.path.join(self.uberenv_path,self.pkg_src_dir))
+            if not os.path.isdir(self.pkg_src_dir):
+                print("[ERROR: package_source_dir '{0}' does not exist]".format(self.pkg_src_dir))
+                sys.exit(-1)
 
     def find_spack_pkg_path_from_hash(self, pkg_name, pkg_hash):
         res, out = sexe("spack/bin/spack find -p /{0}".format(pkg_hash), ret_output = True)

--- a/uberenv.py
+++ b/uberenv.py
@@ -62,7 +62,6 @@ import json
 import datetime
 import glob
 import re
-import yaml
 
 from optparse import OptionParser
 
@@ -779,6 +778,7 @@ class SpackEnv(UberEnv):
 
         # Update spack's config.yaml if clingo was requested
         if self.use_clingo:
+            import yaml
             with open(pjoin(spack_etc_defaults_dir, "config.yaml"), 'r') as conf_file:
                 conf_data = conf_file.read()
             conf_yaml = yaml.load(conf_data)

--- a/uberenv.py
+++ b/uberenv.py
@@ -1057,7 +1057,7 @@ class SpackEnv(UberEnv):
         """
         try:
             import clingo
-        except ModuleNotFoundError:
+        except ImportError:
             import pip
             pip_ver = pip.__version__
             # Requirement comes from https://github.com/pypa/manylinux


### PR DESCRIPTION
This approach uses the `json` config file to expose the clingo option, which triggers a modification of Spack's `config.yaml` in addition to an install of clingo through `pip`, packaged with https://github.com/joshessman-llnl/package-clingo-manylinux.

~I am in communication with the clingo dev(s) regarding an official PPC build that would allow us to switch over to the official package on PyPI.~ ✔️ This wheel-based approach was selected (instead of spack's bootstrap option) to avoid having to build clingo and its dependencies from source.

As an alternative interface, uberenv could read in the provided `config.yaml` (instead of the json option), see if it specifies the new concretizer, and install clingo accordingly.  Thoughts?