### PR TITLE
Feature/environments

### DIFF
--- a/uberenv.py
+++ b/uberenv.py
@@ -733,7 +733,9 @@ class SpackEnv(UberEnv):
         # this is an opportunity to show spack python info post obtaining spack
         self.print_spack_python_info()
 
-
+# TODO: The hot copy may not be necessary any more, but we will deal with this
+#       after we implement the copy of environments and mirror setting.
+#       note: the feature to use here is: spack repo
         # hot-copy our packages into spack
         if len(self.packages_paths) > 0:
             dest_spack_pkgs = pjoin(self.dest_spack,"var","spack","repos","builtin","packages")

--- a/uberenv.py
+++ b/uberenv.py
@@ -794,7 +794,7 @@ class SpackEnv(UberEnv):
         # environment is well designed.
 
         lock_file=self.spack_config_dir+"/spack.lock"
-        sexe("[[ -e ${0} ]] && rm ${0}")
+        sexe("[[ -e ${0} ]] && rm ${0}".format(lock_file)
 
         self.spack_cmd = "{0} -e {1}".format(self.spack_cmd,self.spack_config_dir)
 

--- a/uberenv.py
+++ b/uberenv.py
@@ -713,10 +713,10 @@ class SpackEnv(UberEnv):
     def load(self):
         # load spack environment, potentially overriding spack defaults
         # uberenv used to handle defaults overriding, now spack environment can
-        # be used to do so, but it relies on each project to make sure their
+        # be used to do so, but it lies with each project to make sure their
         # environment is well designed.
 
-        self.spack_cmd = "{0} -e {1}".format(self.spack_cmd,self.config_dir())
+        self.spack_cmd = "{0} -e {1}".format(self.spack_cmd,self.spack_config_dir)
 
         # A simple proxy script for spack
         uber_spack='#!/bin/bash\n$(dirname ${{0}})/{0} "$@"\n'.format(self.spack_cmd)

--- a/uberenv.py
+++ b/uberenv.py
@@ -340,7 +340,7 @@ class UberEnv():
 
     def set_from_args_or_json(self,setting, optional=True):
         """
-        When optional=False: 
+        When optional=False:
             If the setting key is not in the json file, error and raise an exception.
         When optional=True:
             If the setting key is not in the json file or opts, return None.
@@ -358,7 +358,7 @@ class UberEnv():
 
     def set_from_json(self,setting, optional=True):
         """
-        When optional=False: 
+        When optional=False:
             If the setting key is not in the json file, error and raise an exception.
         When optional=True:
             If the setting key is not in the json file or opts, return None.
@@ -443,7 +443,7 @@ class VcpkgEnv(UberEnv):
 
             os.chdir(self.dest_dir)
 
-            clone_opts = ("-c http.sslVerify=false " 
+            clone_opts = ("-c http.sslVerify=false "
                           if self.opts["ignore_ssl_errors"] else "")
 
             clone_cmd =  "git {0} clone --single-branch -b {1} {2} vcpkg".format(clone_opts, vcpkg_branch,vcpkg_url)
@@ -455,7 +455,7 @@ class VcpkgEnv(UberEnv):
                 print("[info: using vcpkg commit {0}]".format(sha1))
                 os.chdir(self.dest_vcpkg)
                 sexe("git checkout {0}".format(sha1),echo=True)
-                
+
         if self.opts["repo_pull"]:
             # do a pull to make sure we have the latest
             os.chdir(self.dest_vcpkg)
@@ -474,7 +474,7 @@ class VcpkgEnv(UberEnv):
 
     def patch(self):
         """ hot-copy our ports into vcpkg """
-        
+
         import distutils.dir_util
 
         dest_vcpkg_ports = pjoin(self.dest_vcpkg, "ports")
@@ -501,7 +501,7 @@ class VcpkgEnv(UberEnv):
         pass
 
     def install(self):
-        
+
         os.chdir(self.dest_vcpkg)
         install_cmd = "vcpkg.exe "
         install_cmd += "install {0}:{1}".format(self.pkg_name, self.vcpkg_triplet)
@@ -849,7 +849,7 @@ class SpackEnv(UberEnv):
             res = sexe(activate_cmd, echo=True)
             if res != 0:
               return res
-        # when using install or uberenv-pkg mode, create a symlink to the host config 
+        # when using install or uberenv-pkg mode, create a symlink to the host config
         if self.build_mode == "install" or \
            self.build_mode == "uberenv-pkg" \
            or self.use_install:

--- a/uberenv.py
+++ b/uberenv.py
@@ -391,7 +391,7 @@ class VcpkgEnv(UberEnv):
 
         # setup architecture triplet
         self.vcpkg_triplet = self.set_from_args_or_json("vcpkg_triplet")
-        print("Vcpkg triplet: {}".format(self.vcpkg_triplet))
+        print("Vcpkg triplet: {0}".format(self.vcpkg_triplet))
         if self.vcpkg_triplet is None:
            self.vcpkg_triplet = os.getenv("VCPKG_DEFAULT_TRIPLET", "x86-windows")
 
@@ -719,7 +719,7 @@ class SpackEnv(UberEnv):
         self.spack_cmd = "{0} -e {1}".format(self.spack_cmd,self.config_dir())
 
         # A simple proxy script for spack
-        uber_spack='#!/bin/bash\n$(dirname ${{0}})/{} "$@"\n'.format(self.spack_cmd)
+        uber_spack='#!/bin/bash\n$(dirname ${{0}})/{0} "$@"\n'.format(self.spack_cmd)
 
         with open('uber-spack','w+') as script:
             script.write(uber_spack)
@@ -746,11 +746,11 @@ class SpackEnv(UberEnv):
 
     def clean_build(self):
         # clean out any temporary spack build stages
-        cln_cmd = "{} clean ".format(self.spack_cmd)
+        cln_cmd = "{0} clean ".format(self.spack_cmd)
         res = sexe(cln_cmd, echo=True)
 
         # clean out any spack cached stuff
-        cln_cmd = "{} clean --all".format(self.spack_cmd)
+        cln_cmd = "{0} clean --all".format(self.spack_cmd)
         res = sexe(cln_cmd, echo=True)
 
         # check if we need to force uninstall of selected packages
@@ -758,7 +758,7 @@ class SpackEnv(UberEnv):
             if self.project_opts.has_key("spack_clean_packages"):
                 for cln_pkg in self.project_opts["spack_clean_packages"]:
                     if self.find_spack_pkg_path(cln_pkg) is not None:
-                        uninst_cmd = "{} uninstall -f -y --all --dependents ".format(self.spack_cmd) + cln_pkg
+                        uninst_cmd = "{0} uninstall -f -y --all --dependents ".format(self.spack_cmd) + cln_pkg
                         res = sexe(uninst_cmd, echo=True)
 
     def show_info(self):
@@ -793,7 +793,7 @@ class SpackEnv(UberEnv):
         # use the uberenv package to trigger the right builds
         # and build an host-config.cmake file
         if not self.use_install:
-            install_cmd = "{} ".format(self.spack_cmd)
+            install_cmd = "{0} ".format(self.spack_cmd)
             if self.opts["ignore_ssl_errors"]:
                 install_cmd += "-k "
             # build mode -- install path
@@ -931,7 +931,7 @@ class SpackEnv(UberEnv):
         Returns the path of a defaults scoped spack mirror with the
         given name, or None if no mirror exists.
         """
-        res, out = sexe("{} mirror list".format(self.spack_cmd), ret_output=True)
+        res, out = sexe("{0} mirror list".format(self.spack_cmd), ret_output=True)
         mirror_path = None
         for mirror in out.split('\n'):
             if mirror:
@@ -972,7 +972,7 @@ class SpackEnv(UberEnv):
         """
         upstream_path = None
 
-        res, out = sexe('{} config get upstreams'.format(self.spack_cmd), ret_output=True)
+        res, out = sexe('{0} config get upstreams'.format(self.spack_cmd), ret_output=True)
         if (not out) and ("upstreams:" in out):
             out = out.replace(' ', '')
             out = out.replace('install_tree:', '')


### PR DESCRIPTION
Updates #18.

Missing:
- [ ] testing this, of course
- [x] force re-concretization. Either with `spack concretize -f`, or by removing the `spack.lock`. Most likely the latter.
- [ ] pass new mirror to the environment with spack command instead of config edit.
- [ ] copy environment in the uberenv_libs location to modify at will (see previous action).

The methodology here is to start with an empty environment: no spec.
Then uberenv adds the selected spec to the environment.