### PR TITLE
Embiggen error message for outdated pip, document Spack concretizer option

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -24,6 +24,7 @@ The Uberenv project release numbers follow [Semantic Versioning](http://semver.o
 - Allow `.uberenv_config.json` to live at the same level as `uberenv.py`
 - No longer removes symlinks when using the directory of `uberenv.py`
 - Reduce Spack's git history to a bare minimum
+- Better error message for out-of-date `pip`, better documentation for `spack_concretizer` setting
 
 ### Fixed
 

--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -233,3 +233,12 @@ Uberenv also features options to optimize the installation
 
 .. note::
     These options are only currently available for spack.
+
+Spack Concretization
+--------------------
+
+Uberenv provides a ``spack_concretizer`` setting to select the method by which the "concrete" dependency tree is determined.
+The ``original`` option is the default behavior and is often subject to errors where a valid set of constraints fails to
+concretize.  The ``clingo`` option is more robust in this respect but requires the installation of the ``clingo`` Python module.
+This happens automatically when the ``spack_concretizer`` option is set to ``clingo``, but requires ``pip`` >= 19.3 and Python >= 3.6.
+If your ``pip`` version is out of date, Uberenv will prompt you to upgrade it.

--- a/uberenv.py
+++ b/uberenv.py
@@ -1064,9 +1064,12 @@ class SpackEnv(UberEnv):
             # JBE: I think the string comparison is somewhat correct here, if not we'll
             # need to install setuptools for 'packaging.version'
             if pip_ver < "19.3":
-                print("[ERROR: pip version {0} is too old to install clingo".format(pip_ver))
+                print("[!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+                print("  ERROR: pip version {0} is too old to install clingo".format(pip_ver))
                 print("  pip 19.3 is required for PEP 599 support")
-                print("]")
+                print("  Try running the following command to upgrade pip:")
+                print("     python3 -m pip install --user --upgrade pip")
+                print("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!]")
                 sys.exit(1)
             py_interp = sys.executable
             clingo_pkg = "clingo"


### PR DESCRIPTION
Motivated by a discussion with @white238 - the error message as currently written can be easy to miss in the logs.

We also discussed the possibility of just upgrading pip from `uberenv.py` since we're already calling `pip` a few lines down, but I'd have to test whether we can hot-patch Python like that.  It also seems unnecessarily messy.