### PR TITLE
Change `spack clean` calls in Uberenv to preserve stage directories for debugging purposes

### DIFF
--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -108,6 +108,7 @@ Uberenv has a few options that allow you to control how dependencies are built:
   ``--project-json``      File for project specific settings             See :ref:`project_configuration`
   ``--triplet``           (vcpkg) Target architecture and linkage        ``VCPKG_DEFAULT_TRIPLET`` environment variable,
                                                                          if present, ``x86-Windows`` otherwise
+  ``--keep-stage``        Keep stage dirs from previous Uberenv runs     **False**
  ======================= ============================================== ================================================
 
 The ``-k`` option exists for sites where SSL certificate interception undermines fetching

--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -108,7 +108,6 @@ Uberenv has a few options that allow you to control how dependencies are built:
   ``--project-json``      File for project specific settings             See :ref:`project_configuration`
   ``--triplet``           (vcpkg) Target architecture and linkage        ``VCPKG_DEFAULT_TRIPLET`` environment variable,
                                                                          if present, ``x86-Windows`` otherwise
-  ``--keep-stage``        Keep stage dirs from previous Uberenv runs     **False**
  ======================= ============================================== ================================================
 
 The ``-k`` option exists for sites where SSL certificate interception undermines fetching

--- a/uberenv.py
+++ b/uberenv.py
@@ -230,14 +230,6 @@ def parse_args():
                       default=False,
                       help="Only download and setup Spack. No further Spack command will be run.")
 
-    # option to keep staged directories from previous Uberenv runs
-    parser.add_option("--keep-stage",
-                      action="store_true",
-                      dest="keep_stage",
-                      default=False,
-                      help="Keep stage directories from previous Uberenv runs;"
-                           "does not override --clean.")
-    
     ###############
     # parse args
     ###############
@@ -795,14 +787,10 @@ class SpackEnv(UberEnv):
 
 
     def clean_build(self):
-        if not self.opts["keep_stage"]:
-            # clean out any temporary spack build stages
-            cln_cmd = "spack/bin/spack clean "
-            res = sexe(cln_cmd, echo=True)
-
-            # clean out any spack cached stuff
-            cln_cmd = "spack/bin/spack clean --all"
-            res = sexe(cln_cmd, echo=True)
+        # clean out any spack cached stuff (except build stages, downloads, &
+        # spack's bootstrapping software)
+        cln_cmd = "spack/bin/spack clean --misc-cache --failures --python-cache"
+        res = sexe(cln_cmd, echo=True)
 
         # check if we need to force uninstall of selected packages
         if self.opts["spack_clean"]:

--- a/uberenv.py
+++ b/uberenv.py
@@ -796,13 +796,13 @@ class SpackEnv(UberEnv):
 
     def clean_build(self):
         if not self.opts["keep_stage"]:
-           # clean out any temporary spack build stages
-           cln_cmd = "spack/bin/spack clean "
-           res = sexe(cln_cmd, echo=True)
+            # clean out any temporary spack build stages
+            cln_cmd = "spack/bin/spack clean "
+            res = sexe(cln_cmd, echo=True)
 
-           # clean out any spack cached stuff
-           cln_cmd = "spack/bin/spack clean --all"
-           res = sexe(cln_cmd, echo=True)
+            # clean out any spack cached stuff
+            cln_cmd = "spack/bin/spack clean --all"
+            res = sexe(cln_cmd, echo=True)
 
         # check if we need to force uninstall of selected packages
         if self.opts["spack_clean"]:

--- a/uberenv.py
+++ b/uberenv.py
@@ -230,6 +230,7 @@ def parse_args():
                       default=False,
                       help="Only download and setup Spack. No further Spack command will be run.")
 
+
     ###############
     # parse args
     ###############

--- a/uberenv.py
+++ b/uberenv.py
@@ -230,7 +230,14 @@ def parse_args():
                       default=False,
                       help="Only download and setup Spack. No further Spack command will be run.")
 
-
+    # option to keep staged directories from previous Uberenv runs
+    parser.add_option("--keep-stage",
+                      action="store_true",
+                      dest="keep_stage",
+                      default=False,
+                      help="Keep stage directories from previous Uberenv runs;"
+                           "does not override --clean.")
+    
     ###############
     # parse args
     ###############
@@ -788,13 +795,14 @@ class SpackEnv(UberEnv):
 
 
     def clean_build(self):
-        # clean out any temporary spack build stages
-        cln_cmd = "spack/bin/spack clean "
-        res = sexe(cln_cmd, echo=True)
+        if not self.opts["keep_stage"]:
+           # clean out any temporary spack build stages
+           cln_cmd = "spack/bin/spack clean "
+           res = sexe(cln_cmd, echo=True)
 
-        # clean out any spack cached stuff
-        cln_cmd = "spack/bin/spack clean --all"
-        res = sexe(cln_cmd, echo=True)
+           # clean out any spack cached stuff
+           cln_cmd = "spack/bin/spack clean --all"
+           res = sexe(cln_cmd, echo=True)
 
         # check if we need to force uninstall of selected packages
         if self.opts["spack_clean"]:


### PR DESCRIPTION
EDIT: Instead of making the changes described below, I followed
@white238's suggestion and changed the arguments to one of
the `spack clean` calls in Uberenv.

---------------

This commit adds a "--keep-stage" flag that disables the initial
`spack clean` and `spack clean --all` invocations when running
Uberenv. The name of this flag was chosen to evoke the same semantics
as the `--keep-stage` flag in `spack install`, `spack create`,
etc. However, this flag will *not* override the `--clean` flag of the
Uberenv CLI; I assume that if a user calls Uberenv with that flag,
they do intend to forcibly remove installations of previous packages
and their dependents.

The use case for this flag is the following: In one project I work on,
Uberenv is invoked repeatedly with different specs to install several
versions of third-party libraries. On this project, I would like to
keep the staged directories after the first invocation so that my
colleagues can drop into the source files of third-party libraries in
a debugger.