### PR TITLE
Add autopush option for binary cache mirrors

### DIFF
--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -267,13 +267,15 @@ Optimization
 
 Uberenv also features options to optimize the installation
 
- ===================== ============================================== ================================================
-  Option               Description                                    Default
- ===================== ============================================== ================================================
-  ``--mirror``         Location of a Spack mirror                     **None**
-  ``--create-mirror``  Creates a Spack mirror at specified location   **None**
-  ``--upstream``       Location of a Spack upstream                   **None**
- ===================== ============================================== ================================================
+ ====================== ============================================== ================================================
+  Option                Description                                    Default
+ ====================== ============================================== ================================================
+  ``--mirror``          Location of a Spack mirror                     **None**
+  ``--create-mirror``   Creates a Spack mirror at specified location   **None**
+  ``--upstream``        Location of a Spack upstream                   **None**
+  ``--mirror-autopush`` Push binaries to mirror as they are built      False
+  ``--trust-key``       Load the gpg key(s) to the Spack gpg keyring   **None**
+ ====================== ============================================== ================================================
 
 .. note::
     These options are only currently available for spack.

--- a/uberenv.py
+++ b/uberenv.py
@@ -122,6 +122,12 @@ def parse_args():
                       default=None,
                       help="spack mirror directory")
 
+    parser.add_option("--mirror-autopush",
+                      action="store_true",
+                      dest="mirror_autopush",
+                      default=False,
+                      help="Use spack v0.22+ --autopush functionality for binary cache mirrors")
+
     # flag to create mirror
     parser.add_argument("--create-mirror",
                       action="store_true",
@@ -407,7 +413,7 @@ class UberEnv():
 
     def set_from_args_or_json(self,setting, optional=True):
         """
-        When optional=False: 
+        When optional=False:
             If the setting key is not in the json file, error and raise an exception.
         When optional=True:
             If the setting key is not in the json file or args, return None.
@@ -425,7 +431,7 @@ class UberEnv():
 
     def set_from_json(self,setting, optional=True):
         """
-        When optional=False: 
+        When optional=False:
             If the setting key is not in the json file, error and raise an exception.
         When optional=True:
             If the setting key is not in the json file or args, return None.
@@ -509,7 +515,7 @@ class VcpkgEnv(UberEnv):
 
             os.chdir(self.dest_dir)
 
-            clone_args = ("-c http.sslVerify=false " 
+            clone_args = ("-c http.sslVerify=false "
                           if self.args["ignore_ssl_errors"] else "")
 
             clone_cmd =  "git {0} clone --single-branch -b {1} {2} vcpkg".format(clone_args, vcpkg_branch,vcpkg_url)
@@ -1057,7 +1063,7 @@ class SpackEnv(UberEnv):
                 print("[ERROR: Failure of spack install]")
                 return res
 
-        # when using install or uberenv-pkg mode, create a symlink to the host config 
+        # when using install or uberenv-pkg mode, create a symlink to the host config
         if self.build_mode == "install" or \
            self.build_mode == "uberenv-pkg" \
            or self.use_install:
@@ -1157,6 +1163,7 @@ class SpackEnv(UberEnv):
         mirror_name = self.pkg_name
         mirror_path = self.get_mirror_path()
         existing_mirror_path = self.find_spack_mirror(mirror_name)
+        autopush = "--autopush" if self.mirror_autopush else ""
 
         if existing_mirror_path and mirror_path != existing_mirror_path:
             # Existing mirror has different URL, error out
@@ -1171,8 +1178,8 @@ class SpackEnv(UberEnv):
             existing_mirror_path = None
         if not existing_mirror_path:
             # Add if not already there
-            sexe("{0} mirror add --scope=defaults {1} {2}".format(
-                    self.spack_exe(), mirror_name, mirror_path), echo=True)
+            sexe("{0} mirror add --scope=defaults {1} {2} {3}".format(
+                    self.spack_exe_path(), autopush, mirror_name, mirror_path), echo=True)
             print("[using mirror {0}]".format(mirror_path))
 
     def find_spack_upstream(self, upstream_name):

--- a/uberenv.py
+++ b/uberenv.py
@@ -1279,7 +1279,7 @@ class SpackEnv(UberEnv):
             print("[--trust-key requires a gpg key path]")
         key_path = pabs(key_path)
         print("[adding gpg keys to spack gpg keyring]")
-        sexe("{0} gpg trust {1}".format(self.spack_exe(), key_path), echo=True)
+        sexe("{0} gpg trust {1}".format(self.spack_exe(use_spack_env=False), key_path), echo=True)
 
 def find_osx_sdks():
     """

--- a/uberenv.py
+++ b/uberenv.py
@@ -1281,17 +1281,17 @@ class SpackEnv(UberEnv):
             print("[adding gpg key to spack gpg keyring]")
             sexe("{0} gpg trust {1}".format(self.spack_exe(use_spack_env=False), key_path), echo=True)
 
-    def find_osx_sdks():
-        """
-        Finds installed osx sdks, returns dict mapping version to file system path
-        """
-        res = {}
-        sdks = glob.glob("/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX*.sdk")
-        for sdk in sdks:
-            sdk_base = os.path.split(sdk)[1]
-            ver = sdk_base[len("MacOSX"):sdk_base.rfind(".")]
-            res[ver] = sdk
-        return res
+def find_osx_sdks():
+    """
+    Finds installed osx sdks, returns dict mapping version to file system path
+    """
+    res = {}
+    sdks = glob.glob("/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX*.sdk")
+    for sdk in sdks:
+        sdk_base = os.path.split(sdk)[1]
+        ver = sdk_base[len("MacOSX"):sdk_base.rfind(".")]
+        res[ver] = sdk
+    return res
 
 def setup_osx_sdk_env_vars():
     """

--- a/uberenv.py
+++ b/uberenv.py
@@ -1282,16 +1282,16 @@ class SpackEnv(UberEnv):
             sexe("{0} gpg trust {1}".format(self.spack_exe(use_spack_env=False), key_path), echo=True)
 
     def find_osx_sdks():
-    """
-    Finds installed osx sdks, returns dict mapping version to file system path
-    """
-    res = {}
-    sdks = glob.glob("/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX*.sdk")
-    for sdk in sdks:
-        sdk_base = os.path.split(sdk)[1]
-        ver = sdk_base[len("MacOSX"):sdk_base.rfind(".")]
-        res[ver] = sdk
-    return res
+        """
+        Finds installed osx sdks, returns dict mapping version to file system path
+        """
+        res = {}
+        sdks = glob.glob("/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX*.sdk")
+        for sdk in sdks:
+            sdk_base = os.path.split(sdk)[1]
+            ver = sdk_base[len("MacOSX"):sdk_base.rfind(".")]
+            res[ver] = sdk
+        return res
 
 def setup_osx_sdk_env_vars():
     """

--- a/uberenv.py
+++ b/uberenv.py
@@ -299,6 +299,13 @@ def parse_args():
                       default=None,
                       help="Path to Spack Environment file (e.g. spack.yaml or spack.lock)")
 
+    # option to add trusted keys to spack gpg keyring
+    parser.add_option("--trust-keys",
+                      action="store_true",
+                      dest="key_path",
+                      default=None,
+                      help="Add the gpg keys to the spack gpg keyring")
+
     ###############
     # parse args
     ###############
@@ -1264,6 +1271,16 @@ class SpackEnv(UberEnv):
                 print("[ERROR: Clingo install failed with returncode {0}]".format(res))
                 sys.exit(-1)
 
+    def trust_gpg_keys(self):
+        """
+        Tells spack to trust the gpg keys at keypath.
+        """
+        key_path = self.opts["key_path"]
+        if not key_path:
+            print("[--trust-key requires a gpg key path]")
+        key_path = pabs(key_path)
+        print("[adding gpg keys to spack gpg keyring]")
+        sexe("gpg trust {0}".format(key_path))
 
 def find_osx_sdks():
     """
@@ -1329,6 +1346,10 @@ def main():
 
     # Setup the necessary paths and directories
     env.setup_paths_and_dirs()
+
+    # Trust keys if the option was provided
+    if args["key_path"]:
+        env.trust_gpg_keys()
 
     # Go to package manager's destination
     os.chdir(env.dest_dir)

--- a/uberenv.py
+++ b/uberenv.py
@@ -301,7 +301,6 @@ def parse_args():
 
     # option to add trusted keys to spack gpg keyring
     parser.add_argument("--trust-keys",
-                      action="store_true",
                       dest="key_path",
                       default=None,
                       help="Add the gpg keys to the spack gpg keyring")

--- a/uberenv.py
+++ b/uberenv.py
@@ -300,8 +300,9 @@ def parse_args():
                       help="Path to Spack Environment file (e.g. spack.yaml or spack.lock)")
 
     # option to add trusted keys to spack gpg keyring
-    parser.add_argument("--trust-key",
-                      dest="key_path",
+    parser.add_argument("--trust-keys",
+                      dest="key_paths",
+                      action="append",
                       default=None,
                       help="Add the gpg keys to the spack gpg keyring")
 
@@ -1270,18 +1271,17 @@ class SpackEnv(UberEnv):
                 print("[ERROR: Clingo install failed with returncode {0}]".format(res))
                 sys.exit(-1)
 
-    def trust_gpg_key(self):
+    def trust_gpg_keys(self):
         """
         Tells spack to trust the gpg keys at keypath.
         """
-        key_path = self.args["key_path"]
-        if not key_path:
-            print("[--trust-key requires a gpg key path]")
-        key_path = pabs(key_path)
-        print("[adding gpg keys to spack gpg keyring]")
-        sexe("{0} gpg trust {1}".format(self.spack_exe(use_spack_env=False), key_path), echo=True)
+        key_paths = self.args["key_paths"]
+        for key_path in key_paths:
+            key_path = pabs(key_path)
+            print("[adding gpg key to spack gpg keyring]")
+            sexe("{0} gpg trust {1}".format(self.spack_exe(use_spack_env=False), key_path), echo=True)
 
-def find_osx_sdks():
+    def find_osx_sdks():
     """
     Finds installed osx sdks, returns dict mapping version to file system path
     """
@@ -1359,7 +1359,7 @@ def main():
 
         # Trust keys if the option was provided
         if args["key_path"]:
-            env.trust_gpg_key()
+            env.trust_gpg_keys()
 
         # Clean the build
         env.clean_build()

--- a/uberenv.py
+++ b/uberenv.py
@@ -1273,7 +1273,7 @@ class SpackEnv(UberEnv):
 
     def trust_gpg_keys(self):
         """
-        Tells spack to trust the gpg keys at keypath.
+        Tells spack to trust the gpg keys in key_paths.
         """
         key_paths = self.args["key_paths"]
         for key_path in key_paths:

--- a/uberenv.py
+++ b/uberenv.py
@@ -1163,7 +1163,7 @@ class SpackEnv(UberEnv):
         mirror_name = self.pkg_name
         mirror_path = self.get_mirror_path()
         existing_mirror_path = self.find_spack_mirror(mirror_name)
-        autopush = "--autopush" if self.mirror_autopush else ""
+        autopush = "--autopush" if self.args["mirror_autopush"] else ""
 
         if existing_mirror_path and mirror_path != existing_mirror_path:
             # Existing mirror has different URL, error out

--- a/uberenv.py
+++ b/uberenv.py
@@ -1358,7 +1358,7 @@ def main():
         env.patch()
 
         # Trust keys if the option was provided
-        if args["key_path"]:
+        if args["key_paths"]:
             env.trust_gpg_keys()
 
         # Clean the build

--- a/uberenv.py
+++ b/uberenv.py
@@ -300,7 +300,7 @@ def parse_args():
                       help="Path to Spack Environment file (e.g. spack.yaml or spack.lock)")
 
     # option to add trusted keys to spack gpg keyring
-    parser.add_argument("--trust-keys",
+    parser.add_argument("--trust-key",
                       dest="key_paths",
                       action="append",
                       default=None,

--- a/uberenv.py
+++ b/uberenv.py
@@ -300,7 +300,7 @@ def parse_args():
                       help="Path to Spack Environment file (e.g. spack.yaml or spack.lock)")
 
     # option to add trusted keys to spack gpg keyring
-    parser.add_option("--trust-keys",
+    parser.add_argument("--trust-keys",
                       action="store_true",
                       dest="key_path",
                       default=None,

--- a/uberenv.py
+++ b/uberenv.py
@@ -1179,7 +1179,7 @@ class SpackEnv(UberEnv):
         if not existing_mirror_path:
             # Add if not already there
             sexe("{0} mirror add --scope=defaults {1} {2} {3}".format(
-                    self.spack_exe_path(), autopush, mirror_name, mirror_path), echo=True)
+                    self.spack_exe(), autopush, mirror_name, mirror_path), echo=True)
             print("[using mirror {0}]".format(mirror_path))
 
     def find_spack_upstream(self, upstream_name):

--- a/uberenv.py
+++ b/uberenv.py
@@ -1275,7 +1275,7 @@ class SpackEnv(UberEnv):
         """
         Tells spack to trust the gpg keys at keypath.
         """
-        key_path = self.opts["key_path"]
+        key_path = self.args["key_path"]
         if not key_path:
             print("[--trust-key requires a gpg key path]")
         key_path = pabs(key_path)

--- a/uberenv.py
+++ b/uberenv.py
@@ -122,11 +122,11 @@ def parse_args():
                       default=None,
                       help="spack mirror directory")
 
-    parser.add_option("--mirror-autopush",
-                      action="store_true",
-                      dest="mirror_autopush",
-                      default=False,
-                      help="Use spack v0.22+ --autopush functionality for binary cache mirrors")
+    parser.add_argument("--mirror-autopush",
+                       action="store_true",
+                       dest="mirror_autopush",
+                       default=False,
+                       help="Use spack v0.22+ --autopush functionality for binary cache mirrors")
 
     # flag to create mirror
     parser.add_argument("--create-mirror",

--- a/uberenv.py
+++ b/uberenv.py
@@ -1346,10 +1346,6 @@ def main():
     # Setup the necessary paths and directories
     env.setup_paths_and_dirs()
 
-    # Trust keys if the option was provided
-    if args["key_path"]:
-        env.trust_gpg_key()
-
     # Go to package manager's destination
     os.chdir(env.dest_dir)
 
@@ -1360,6 +1356,10 @@ def main():
 
         # Patch the package manager, as necessary
         env.patch()
+
+        # Trust keys if the option was provided
+        if args["key_path"]:
+            env.trust_gpg_key()
 
         # Clean the build
         env.clean_build()

--- a/uberenv.py
+++ b/uberenv.py
@@ -300,7 +300,7 @@ def parse_args():
                       help="Path to Spack Environment file (e.g. spack.yaml or spack.lock)")
 
     # option to add trusted keys to spack gpg keyring
-    parser.add_argument("--trust-keys",
+    parser.add_argument("--trust-key",
                       dest="key_path",
                       default=None,
                       help="Add the gpg keys to the spack gpg keyring")
@@ -1270,7 +1270,7 @@ class SpackEnv(UberEnv):
                 print("[ERROR: Clingo install failed with returncode {0}]".format(res))
                 sys.exit(-1)
 
-    def trust_gpg_keys(self):
+    def trust_gpg_key(self):
         """
         Tells spack to trust the gpg keys at keypath.
         """
@@ -1279,7 +1279,7 @@ class SpackEnv(UberEnv):
             print("[--trust-key requires a gpg key path]")
         key_path = pabs(key_path)
         print("[adding gpg keys to spack gpg keyring]")
-        sexe("gpg trust {0}".format(key_path))
+        sexe("{0} gpg trust {1}".format(self.spack_exe(), key_path), echo=True)
 
 def find_osx_sdks():
     """
@@ -1348,7 +1348,7 @@ def main():
 
     # Trust keys if the option was provided
     if args["key_path"]:
-        env.trust_gpg_keys()
+        env.trust_gpg_key()
 
     # Go to package manager's destination
     os.chdir(env.dest_dir)


### PR DESCRIPTION
This adds a CLI option to enable Spack's auto push feature for binary mirrors and an option to add trusted gpg keys to the spack keyring. 