### PR TITLE
Revert `spack_setup_clingo` option back to using boolean values

### DIFF
--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -223,7 +223,7 @@ Project settings are as follows:
   spack_build_mode         ``--spack-build-mode``     Set mode used to build TPLs with Spack           ``dev-build``
   spack_configs_path       **None**                   Directory with Spack configs to be autodetected  ``spack_configs``
   spack_packages_path      **None**                   Directory|List with Package Repos to be added    ``packages``
-  spack_setup_clingo       **None**                   Do not install clingo if set to string ``false`` **None**
+  spack_setup_clingo       **None**                   Do not install clingo if set to ``false``        **None**
   spack_externals          ``--spack-externals``      Space delimited string of packages for Spack to  **None**
                                                       search for externals
   spack_compiler_paths     ``--spack-compiler-paths`` Space delimited string of paths for Spack to     **None**

--- a/uberenv.py
+++ b/uberenv.py
@@ -880,7 +880,7 @@ class SpackEnv(UberEnv):
         self.disable_spack_config_scopes()
 
         # setup clingo (unless specified not to)
-        if "spack_setup_clingo" in self.project_args and self.project_args["spack_setup_clingo"].lower() == "false":
+        if "spack_setup_clingo" in self.project_args and self.project_args["spack_setup_clingo"] == False:
             print("[info: clingo will not be installed by uberenv]")
         else:
             self.setup_clingo()


### PR DESCRIPTION
I had mistakenly assumed that JSON `false` did not convert to Python `False` when decoding JSON files. This PR reverts the option back to using boolean type. Thank you @adrienbernede for pointing this out.