### PR TITLE
Adds logic to copy `versions.yaml` and `defaults.yaml` to spack environment

### DIFF
--- a/uberenv.py
+++ b/uberenv.py
@@ -756,7 +756,10 @@ class SpackEnv(UberEnv):
           print("[checking for '{0}' yaml file]".format(_src))
           if os.path.exists(_src):
             print("[copying '{0}' config file to {1}]".format(_config_file, _dst))
-            sexe("cp {0} {1}".format(_src, _dst))
+            if os.path.exists(_dst):
+                raise FileExistsError(f"The file '{_dst}' already exists.")
+            else:
+                shutil.copy(_src, _dst)
 
         # If you still could not find a spack.yaml, create one later on
         if self.spack_env_file is None:

--- a/uberenv.py
+++ b/uberenv.py
@@ -544,7 +544,7 @@ class VcpkgEnv(UberEnv):
         dest_vcpkg_ports = pjoin(self.dest_vcpkg, "ports")
 
         print("[info: copying from {0} to {1}]".format(self.vcpkg_ports_path, dest_vcpkg_ports))
-        shutil.copytree(self.vcpkg_ports_path, dest_vcpkg_ports)
+        shutil.copytree(self.vcpkg_ports_path, dest_vcpkg_ports, dirs_exist_ok=True)
 
 
     def clean_build(self):

--- a/uberenv.py
+++ b/uberenv.py
@@ -756,10 +756,7 @@ class SpackEnv(UberEnv):
           print("[checking for '{0}' yaml file]".format(_src))
           if os.path.exists(_src):
             print("[copying '{0}' config file to {1}]".format(_config_file, _dst))
-            if os.path.exists(_dst):
-                raise FileExistsError(f"The file '{_dst}' already exists.")
-            else:
-                shutil.copy(_src, _dst)
+            shutil.copy(_src, _dst)
 
         # If you still could not find a spack.yaml, create one later on
         if self.spack_env_file is None:

--- a/uberenv.py
+++ b/uberenv.py
@@ -706,6 +706,7 @@ class SpackEnv(UberEnv):
 
 
     def setup_paths_and_dirs(self):
+        print("[setting up paths for environment]")
         # get the current working path
 
         UberEnv.setup_paths_and_dirs(self)
@@ -747,6 +748,15 @@ class SpackEnv(UberEnv):
                 else:
                     print("[WARNING: Could not find Spack Environment file (e.g. spack.yaml) under: {0}]".format(self.spack_env_file))
                     self.spack_env_file = None
+
+        # Copy "defaults.yaml" and "versions.yaml" from configs dir, if they exist
+        for _config_file in ("defaults.yaml", "versions.yaml"):
+          _src = pjoin(spack_configs_path, _config_file)
+          _dst = pabs(pjoin(self.spack_env_directory, "..", _config_file))
+          print("[checking for '{0}' yaml file]".format(_src))
+          if os.path.exists(_src):
+            print("[copying '{0}' config file to {1}]".format(_config_file, _dst))
+            sexe("cp {0} {1}".format(_src, _dst))
 
         # If you still could not find a spack.yaml, create one later on
         if self.spack_env_file is None:


### PR DESCRIPTION
I'm using these files to consolidate shared versions (`versions.yaml`) and variants (`defaults.yaml`) for Axom's spack dependencies -- see https://github.com/LLNL/axom/pull/1574
In particular:
* `versions.yaml`: https://github.com/LLNL/axom/pull/1574/files#diff-45e557c81c8209d8dbeb4f52a0239eccc53c22a6c51ced39435349181ab3cbf7
* `defaults.yaml`: https://github.com/LLNL/axom/pull/1574/files#diff-5a7a33e81cb3fe713d044826e14c10cc58301354f60d2b5526e1e2068664a050
* and a platform env file: https://github.com/LLNL/axom/pull/1574/files#diff-88c7deb79649cce5aa1507c32ec80b76fcc3cbc0907283356600f1389dddd37e

This initial implementation might be too specific to Axom's use-case.
If so, we might want to add a new Uberenv config variable with a list of files top copy over, rather than hardcoding them.

I'm open to suggestions...