### PR TITLE
add bootstrap defense

### DIFF
--- a/uberenv.py
+++ b/uberenv.py
@@ -980,7 +980,7 @@ class SpackEnv(UberEnv):
     def clean_build(self):
         # clean out any spack cached stuff (except build stages, downloads)
         # note: we now clean out spack bootstrap b/c ~/.spack contents can undermine bootstrap
-        cln_cmd = "{0} clean -b --misc-cache --failures --python-cache".format(self.spack_exe(use_spack_env=False))
+        cln_cmd = "{0} clean --bootstrap --misc-cache --failures --python-cache".format(self.spack_exe(use_spack_env=False))
         res = sexe(cln_cmd, echo=True)
 
         # check if we need to force uninstall of selected packages


### PR DESCRIPTION
spack configs created with post 1.0 spack will undermine bootstrap of older spack (0.23.0) - here is an example of the error message you get:

```
[exe: /Users/harrison37/Work/github/llnl/conduit/_jhhh/spack/bin/spack -D /Users/harrison37/Work/github/llnl/conduit/_jhhh/spack_env concretize --fresh ]
==> Error: a single spec was requested, but parsed more than one:
gcc@14.2.0 languages:=fortran
          ^^^^^^^^^^^^^^^^^^^
```

Note the `:=` syntax is newer then spack 0.23.0


This adds `-b` to the our clean command, to re-bootstrap and avoid config issues from undermining builds.