### PR TITLE
Add spack package URL, tag, and branch overrides

### DIFF
--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -224,8 +224,11 @@ Project settings are as follows:
   spack_activate           **None**                   Spack packages to activate                       **None**
   spack_build_mode         ``--spack-build-mode``     Set mode used to build TPLs with Spack           ``dev-build``
   spack_configs_path       **None**                   Directory with Spack configs to be autodetected  ``spack_configs``
+  spack_packages_url       **None**                   Download url for Spack packages                  ``https://github.com/spack/spack-packages.git``
   spack_packages_path      **None**                   Directory|List with Package Repos to be added    ``packages``
+  spack_packages_branch    **None**                   Spack packages repo branch to checkout           **None**
   spack_packages_commit    **None**                   Spack packages repo commit to checkout           **None**
+  spack_packages_tag       **None**                   Spack packages repo tag to checkout.             **None**
   spack_setup_clingo       **None**                   Do not install clingo if set to ``false``        **None**
   spack_externals          ``--spack-externals``      Space delimited string of packages for Spack to  **None**
                                                       search for externals

--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -241,6 +241,8 @@ Project settings are as follows:
  ========================= ========================== ================================================ =======================================
 
 If a ``spack_commit`` is present, it supercedes the ``spack_branch`` option, and similarly for ``vcpkg_commit``and ``vcpkg_branch``.
+The precedence for the Spack packages repo options are ``spack_packages_commit``, ``spack_packages_branch``, and last ``spack_packages_tag``.
+If none of these are given, Spack will pull the current commit on their default branch.
 
 When used as a submodule ``.uberenv_config.json`` should define both ``spack_configs_path`` and ``spack_packages_path``,
 providing Uberenv with the respective location of ``spack_configs`` and ``packages`` directories.

--- a/uberenv.py
+++ b/uberenv.py
@@ -871,12 +871,18 @@ class SpackEnv(UberEnv):
 
             # Optionally, check out Spack's builtin package repo to a specific commit/branch/tag
             if "spack_packages_url" in self.project_args:
-                url = self.project_args["spack_packages_url"]
-
-                spack_repo_update_cmd = f"{self.spack_exe(use_spack_env=False)} repo update --remote {url} builtin"
-                res = sexe(spack_repo_update_cmd, echo=True)
+                spack_repo_remove_cmd = f"{self.spack_exe(use_spack_env=False)} repo remove builtin"
+                res = sexe(spack_repo_remove_cmd, echo=True)
                 if res != 0:
-                    print("[ERROR: Failed to update git URL for builtin package repository]")
+                    print("[ERROR: Failed to remove builtin package repository so it could be re-added with given URL]")
+                    sys.exit(-1)
+
+                # Now add it back with the correct url
+                url = self.project_args["spack_packages_url"]
+                spack_repo_add_cmd = f"{self.spack_exe(use_spack_env=False)} repo add --name builtin {url}"
+                res = sexe(spack_repo_add_cmd, echo=True)
+                if res != 0:
+                    print("[ERROR: Failed to add builtin package repository with given URL]")
                     sys.exit(-1)
 
             # Optionally, check out Spack's builtin package repo to a specific commit/branch/tag

--- a/uberenv.py
+++ b/uberenv.py
@@ -869,7 +869,17 @@ class SpackEnv(UberEnv):
                 print("[ERROR: Failed to set builtin package repository destination]")
                 sys.exit(-1)
 
-            # Optionally, check out Spack's builtin package repo to a specific commit
+            # Optionally, check out Spack's builtin package repo to a specific commit/branch/tag
+            if "spack_packages_url" in self.project_args:
+                url = self.project_args["spack_packages_url"]
+
+                spack_repo_update_cmd = f"{self.spack_exe(use_spack_env=False)} repo update --remote {url} builtin"
+                res = sexe(spack_repo_update_cmd, echo=True)
+                if res != 0:
+                    print("[ERROR: Failed to update git URL for builtin package repository]")
+                    sys.exit(-1)
+
+            # Optionally, check out Spack's builtin package repo to a specific commit/branch/tag
             if "spack_packages_commit" in self.project_args:
                 sha1 = self.project_args["spack_packages_commit"]
 
@@ -878,8 +888,24 @@ class SpackEnv(UberEnv):
                 if res != 0:
                     print("[ERROR: Failed to update git commit for builtin package repository]")
                     sys.exit(-1)
+            elif "spack_packages_branch" in self.project_args:
+                branch = self.project_args["spack_packages_branch"]
+
+                spack_repo_update_cmd = f"{self.spack_exe(use_spack_env=False)} repo update --branch {branch} builtin"
+                res = sexe(spack_repo_update_cmd, echo=True)
+                if res != 0:
+                    print("[ERROR: Failed to update git branch for builtin package repository]")
+                    sys.exit(-1)
+            elif "spack_packages_tag" in self.project_args:
+                tag = self.project_args["spack_packages_tag"]
+
+                spack_repo_update_cmd = f"{self.spack_exe(use_spack_env=False)} repo update --tag {tag} builtin"
+                res = sexe(spack_repo_update_cmd, echo=True)
+                if res != 0:
+                    print("[ERROR: Failed to update git tag for builtin package repository]")
+                    sys.exit(-1)
             else:
-                print("[info: user did not specify `spack_packages_commit`, Spack will pull the spack-packages repo at develop]")
+                print("[info: User did not specify any `spack_packages_*` override, Spack will pull the spack-packages repo at develop]")
 
 
     def disable_spack_config_scopes(self):


### PR DESCRIPTION
I tested URL, tag, and branch but I get the following error with apple git:

```
[exe: /Users/white238/projects/uberenv/repo/uberenv_libs/spack/bin/spack repo update --tag develop-2025-07-13 builtin]
remote: Enumerating objects: 19569, done.
remote: Counting objects: 100% (19569/19569), done.
remote: Compressing objects: 100% (10512/10512), done.
remote: Total 19569 (delta 1300), reused 13548 (delta 1221), pack-reused 0 (from 0)
error: pathspec 'develop-2025-07-13' did not match any file(s) known to git
==> Error: Failed to update repository builtin
[ERROR: Failed to update git tag for builtin package repository]
```

I say we can merge this.