### PR TITLE
keep builtin destination upon removing old builtin repo

### DIFF
--- a/uberenv.py
+++ b/uberenv.py
@@ -859,7 +859,6 @@ class SpackEnv(UberEnv):
                 sys.exit(-1)
 
 
-
     def disable_spack_config_scopes(self):
         # disables all config scopes except "defaults", which we will
         # force our settings into
@@ -921,13 +920,6 @@ class SpackEnv(UberEnv):
 
             # Optionally, check out Spack's builtin package repo to a specific commit/branch/tag
             if "spack_packages_url" in self.project_args:
-                spack_repo_remove_cmd = f"{self.spack_exe()} repo remove builtin"
-                res = sexe(spack_repo_remove_cmd, echo=True)
-                if res != 0:
-                    print("[ERROR: Failed to remove builtin package repository so it could be re-added with given URL]")
-                    sys.exit(-1)
-
-                # Now add it back with the correct url
                 url = self.project_args["spack_packages_url"]
                 spack_repo_add_cmd = f"{self.spack_exe()} repo add --name builtin {url}"
                 res = sexe(spack_repo_add_cmd, echo=True)


### PR DESCRIPTION
the builtin repo's destination was being ignored due to the ordering of spack commands. this pr fixes that, so the destination is kept.

also does these changes in spack environment, so you can see the changes in the spack.yaml. for example

```yaml
  repos:
    serac: /usr/WS2/meemee/serac/repo/scripts/spack
    llnl_radiuss: /usr/WS2/meemee/serac/repo/scripts/spack/radiuss-spack-configs/spack_repo/llnl_radiuss
    builtin:
      git: https://github.com/spack/spack-packages.git
      destination: /usr/WS2/meemee/serac/serac_tpls/toss_4_x86_64_ib_cray/2025_10_14_17_32_44/builtin_spack_packages_repo
      commit: a75a7f75182ffc7a51c6ca7f0fec4bf9b2705be8
```

also removes this section since i think it only worked because the destination was set in the wrong order

```py
spack_repo_remove_cmd = f"{self.spack_exe(use_spack_env=False)} repo remove builtin"
res = sexe(spack_repo_remove_cmd, echo=True)
if res != 0:
  print("[ERROR: Failed to remove builtin package repository so it could be re-added with given URL]")
  sys.exit(-1)
```