### PR TITLE
Prevent mixing compilers in Spack versions over 1.1.0

### DIFF
--- a/.ci/test-project/packages/magictestlib/package.py
+++ b/.ci/test-project/packages/magictestlib/package.py
@@ -48,8 +48,6 @@ import shutil
 import socket
 from os import environ as env
 
-import llnl.util.tty as tty
-
 from spack.package import *
 
 
@@ -153,7 +151,6 @@ class Magictestlib(Package):
         cfg.close()
 
         host_cfg_fname = os.path.abspath(host_cfg_fname)
-        tty.info("spack generated host-config file: " + host_cfg_fname)
 
     # Copy the generated host-config to install directory for downstream use
     @run_before("install")

--- a/.ci/test-project/packages/magictestlib_cached/package.py
+++ b/.ci/test-project/packages/magictestlib_cached/package.py
@@ -48,9 +48,6 @@ import os
 import socket
 from os import environ as env
 
-import llnl.util.tty as tty
-
-
 class MagictestlibCached(CachedCMakePackage):
     """MagictestlibCached"""
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Run Uberenv
         run: |
-          pip install packaging
+          pip3 install packaging
           cd  .ci/test-project
           python3 ../../uberenv.py --project-json=uberenv_configs/uberenv-pkg.json
           cat uberenv_libs/*.cmake

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Run Uberenv
         run: |
+          pip install packaging
           cd  .ci/test-project
           python3 ../../uberenv.py --project-json=uberenv_configs/uberenv-pkg.json
           cat uberenv_libs/*.cmake

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -13,10 +13,6 @@ jobs:
       - uses: actions/checkout@v3
       - name: Run Uberenv
         run: |
-          python3 -m venv venv
-          source venv/bin/activate
-          pip3 install --upgrade pip
-          pip3 install packaging
           cd  .ci/test-project
           python3 ../../uberenv.py --project-json=uberenv_configs/uberenv-pkg.json
           cat uberenv_libs/*.cmake

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -13,6 +13,9 @@ jobs:
       - uses: actions/checkout@v3
       - name: Run Uberenv
         run: |
+          python3 -m venv venv
+          source venv/bin/activate
+          pip3 install --upgrade pip
           pip3 install packaging
           cd  .ci/test-project
           python3 ../../uberenv.py --project-json=uberenv_configs/uberenv-pkg.json

--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -211,34 +211,35 @@ is found in the in the following order:
 
 Project settings are as follows:
 
- ========================= ========================== ================================================ =======================================
-  Setting                  Command line Option        Description                                      Default
- ========================= ========================== ================================================ =======================================
-  package_name             ``--package-name``         Spack package name                               **None**
-  package_version          **None**                   Spack package version                            **None**
-  package_final_phase      ``--package-final-phase``  Controls after which phase Spack should stop     **None**
-  package_source_dir       ``--package-source-dir``   Controls the source directory Spack should use   **None**
-  force_commandline_prefix **None**                   Force user to specify `--prefix` on command line ``false``
-  spack_url                **None**                   Download url for Spack                           ``https://github.com/spack/spack.git``
-  spack_commit             **None**                   Spack commit to checkout                         **None**
-  spack_activate           **None**                   Spack packages to activate                       **None**
-  spack_build_mode         ``--spack-build-mode``     Set mode used to build TPLs with Spack           ``dev-build``
-  spack_configs_path       **None**                   Directory with Spack configs to be autodetected  ``spack_configs``
-  spack_packages_url       **None**                   Download url for Spack packages                  ``https://github.com/spack/spack-packages.git``
-  spack_packages_path      **None**                   Directory|List with Package Repos to be added    ``packages``
-  spack_packages_branch    **None**                   Spack packages repo branch to checkout           **None**
-  spack_packages_commit    **None**                   Spack packages repo commit to checkout           **None**
-  spack_packages_tag       **None**                   Spack packages repo tag to checkout.             **None**
-  spack_setup_clingo       **None**                   Do not install clingo if set to ``false``        **None**
-  spack_externals          ``--spack-externals``      Space delimited string of packages for Spack to  **None**
-                                                      search for externals
-  spack_compiler_paths     ``--spack-compiler-paths`` Space delimited string of paths for Spack to     **None**
-                                                      search for compilers
-  vcpkg_url                **None**                   Download url for Vcpkg                           ``https://github.com/microsoft/vcpkg``
-  vcpkg_branch             **None**                   Vcpkg branch to checkout                         ``master``
-  vcpkg_commit             **None**                   Vcpkg commit to checkout                         **None**
-  vcpkg_ports_path         ``--vcpkg-ports-path``     Folder with vcpkg ports files                    **None**
- ========================= ========================== ================================================ =======================================
+ ========================= =========================== ================================================ =======================================
+  Setting                  Command line Option         Description                                      Default
+ ========================= =========================== ================================================ =======================================
+  package_name             ``--package-name``          Spack package name                               **None**
+  package_version          **None**                    Spack package version                            **None**
+  package_final_phase      ``--package-final-phase``   Controls after which phase Spack should stop     **None**
+  package_source_dir       ``--package-source-dir``    Controls the source directory Spack should use   **None**
+  force_commandline_prefix **None**                    Force user to specify `--prefix` on command line ``false``
+  spack_url                **None**                    Download url for Spack                           ``https://github.com/spack/spack.git``
+  spack_commit             **None**                    Spack commit to checkout                         **None**
+  spack_activate           **None**                    Spack packages to activate                       **None**
+  spack_build_mode         ``--spack-build-mode``      Set mode used to build TPLs with Spack           ``dev-build``
+  spack_configs_path       **None**                    Directory with Spack configs to be autodetected  ``spack_configs``
+  spack_packages_url       **None**                    Download url for Spack packages                  ``https://github.com/spack/spack-packages.git``
+  spack_packages_path      **None**                    Directory|List with Package Repos to be added    ``packages``
+  spack_packages_branch    **None**                    Spack packages repo branch to checkout           **None**
+  spack_packages_commit    **None**                    Spack packages repo commit to checkout           **None**
+  spack_packages_tag       **None**                    Spack packages repo tag to checkout.             **None**
+  spack_setup_clingo       **None**                    Do not install clingo if set to ``false``        **None**
+  spack_externals          ``--spack-externals``       Space delimited string of packages for Spack to  **None**
+                                                       search for externals
+  spack_compiler_paths     ``--spack-compiler-paths``  Space delimited string of paths for Spack to     **None**
+                                                       search for compilers
+  spack_compiler_mixing    ``--spack-compiler-mixing`` Enables compiler mixing (Spack 1.1.0+ only)      **None**
+  vcpkg_url                **None**                    Download url for Vcpkg                           ``https://github.com/microsoft/vcpkg``
+  vcpkg_branch             **None**                    Vcpkg branch to checkout                         ``master``
+  vcpkg_commit             **None**                    Vcpkg commit to checkout                         **None**
+  vcpkg_ports_path         ``--vcpkg-ports-path``      Folder with vcpkg ports files                    **None**
+ ========================= =========================== ================================================ =======================================
 
 If a ``spack_commit`` is present, it supercedes the ``spack_branch`` option, and similarly for ``vcpkg_commit``and ``vcpkg_branch``.
 The precedence for the Spack packages repo options are ``spack_packages_commit``, ``spack_packages_branch``, and last ``spack_packages_tag``.

--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -234,7 +234,7 @@ Project settings are as follows:
                                                                     search for externals
   spack_compiler_paths          ``--spack-compiler-paths``          Space delimited string of paths for Spack to     **None**
                                                                     search for compilers
-  spack_disable_compiler_mixing ``--spack-disable-compiler-mixing`` Disables compiler mixing (Spack 1.1.0+ only)     ``false``
+  spack_allow_compiler_mixing   ``--spack-allow-compiler-mixing``   Enables compiler mixing (Spack 1.1.0+ only)      ``false``
   vcpkg_url                     **None**                            Download url for Vcpkg                           ``https://github.com/microsoft/vcpkg``
   vcpkg_branch                  **None**                            Vcpkg branch to checkout                         ``master``
   vcpkg_commit                  **None**                            Vcpkg commit to checkout                         **None**

--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -211,35 +211,35 @@ is found in the in the following order:
 
 Project settings are as follows:
 
- ========================= =========================== ================================================ =======================================
-  Setting                  Command line Option         Description                                      Default
- ========================= =========================== ================================================ =======================================
-  package_name             ``--package-name``          Spack package name                               **None**
-  package_version          **None**                    Spack package version                            **None**
-  package_final_phase      ``--package-final-phase``   Controls after which phase Spack should stop     **None**
-  package_source_dir       ``--package-source-dir``    Controls the source directory Spack should use   **None**
-  force_commandline_prefix **None**                    Force user to specify `--prefix` on command line ``false``
-  spack_url                **None**                    Download url for Spack                           ``https://github.com/spack/spack.git``
-  spack_commit             **None**                    Spack commit to checkout                         **None**
-  spack_activate           **None**                    Spack packages to activate                       **None**
-  spack_build_mode         ``--spack-build-mode``      Set mode used to build TPLs with Spack           ``dev-build``
-  spack_configs_path       **None**                    Directory with Spack configs to be autodetected  ``spack_configs``
-  spack_packages_url       **None**                    Download url for Spack packages                  ``https://github.com/spack/spack-packages.git``
-  spack_packages_path      **None**                    Directory|List with Package Repos to be added    ``packages``
-  spack_packages_branch    **None**                    Spack packages repo branch to checkout           **None**
-  spack_packages_commit    **None**                    Spack packages repo commit to checkout           **None**
-  spack_packages_tag       **None**                    Spack packages repo tag to checkout.             **None**
-  spack_setup_clingo       **None**                    Do not install clingo if set to ``false``        **None**
-  spack_externals          ``--spack-externals``       Space delimited string of packages for Spack to  **None**
-                                                       search for externals
-  spack_compiler_paths     ``--spack-compiler-paths``  Space delimited string of paths for Spack to     **None**
-                                                       search for compilers
-  spack_compiler_mixing    ``--spack-compiler-mixing`` Enables compiler mixing (Spack 1.1.0+ only)      **None**
-  vcpkg_url                **None**                    Download url for Vcpkg                           ``https://github.com/microsoft/vcpkg``
-  vcpkg_branch             **None**                    Vcpkg branch to checkout                         ``master``
-  vcpkg_commit             **None**                    Vcpkg commit to checkout                         **None**
-  vcpkg_ports_path         ``--vcpkg-ports-path``      Folder with vcpkg ports files                    **None**
- ========================= =========================== ================================================ =======================================
+ ============================== =================================== ================================================ =======================================
+  Setting                       Command line Option                 Description                                      Default
+ ============================== =================================== ================================================ =======================================
+  package_name                  ``--package-name``                  Spack package name                               **None**
+  package_version               **None**                            Spack package version                            **None**
+  package_final_phase           ``--package-final-phase``           Controls after which phase Spack should stop     **None**
+  package_source_dir            ``--package-source-dir``            Controls the source directory Spack should use   **None**
+  force_commandline_prefix      **None**                            Force user to specify `--prefix` on command line ``false``
+  spack_url                     **None**                            Download url for Spack                           ``https://github.com/spack/spack.git``
+  spack_commit                  **None**                            Spack commit to checkout                         **None**
+  spack_activate                **None**                            Spack packages to activate                       **None**
+  spack_build_mode              ``--spack-build-mode``              Set mode used to build TPLs with Spack           ``dev-build``
+  spack_configs_path            **None**                            Directory with Spack configs to be autodetected  ``spack_configs``
+  spack_packages_url            **None**                            Download url for Spack packages                  ``https://github.com/spack/spack-packages.git``
+  spack_packages_path           **None**                            Directory|List with Package Repos to be added    ``packages``
+  spack_packages_branch         **None**                            Spack packages repo branch to checkout           **None**
+  spack_packages_commit         **None**                            Spack packages repo commit to checkout           **None**
+  spack_packages_tag            **None**                            Spack packages repo tag to checkout.             **None**
+  spack_setup_clingo            **None**                            Do not install clingo if set to ``false``        **None**
+  spack_externals               ``--spack-externals``               Space delimited string of packages for Spack to  **None**
+                                                                    search for externals
+  spack_compiler_paths          ``--spack-compiler-paths``          Space delimited string of paths for Spack to     **None**
+                                                                    search for compilers
+  spack_disable_compiler_mixing ``--spack-disable-compiler-mixing`` Disables compiler mixing (Spack 1.1.0+ only)     ``false``
+  vcpkg_url                     **None**                            Download url for Vcpkg                           ``https://github.com/microsoft/vcpkg``
+  vcpkg_branch                  **None**                            Vcpkg branch to checkout                         ``master``
+  vcpkg_commit                  **None**                            Vcpkg commit to checkout                         **None**
+  vcpkg_ports_path              ``--vcpkg-ports-path``              Folder with vcpkg ports files                    **None**
+ ============================== =================================== ================================================ =======================================
 
 If a ``spack_commit`` is present, it supercedes the ``spack_branch`` option, and similarly for ``vcpkg_commit``and ``vcpkg_branch``.
 The precedence for the Spack packages repo options are ``spack_packages_commit``, ``spack_packages_branch``, and last ``spack_packages_tag``.

--- a/uberenv.py
+++ b/uberenv.py
@@ -63,7 +63,6 @@ import glob
 import re
 import argparse
 
-from packaging.version import Version
 from functools import partial
 
 from os import environ as env
@@ -366,6 +365,22 @@ def find_project_config(args):
                 lookup_path = pabs(os.path.join(lookup_path, os.pardir))
     print("ERROR: No Uberenv configuration json file found")
     sys.exit(-1)
+
+def version2tuple(version: str) -> tuple[int, int, int]:
+    """
+    Converts version string (major.minor.patch.other) to tuple (major, minor, patch).
+    Add missing 0's if not all three version numbers are supplied (e.g. "1" -> (1, 0, 0))
+
+    Example usage:
+    version2tuple(self.spack_version()) >= version2tuple("1.2.0")
+
+    :param version: Version string (major.minor.patch.other)
+    :type version: str
+    """
+    raw_parts = version.split(".")[:3]
+    parts = [p if p != "" else "0" for p in raw_parts]
+    parts += ["0"] * (3 - len(parts))
+    return tuple(map(int, parts))
 
 
 class UberEnv():
@@ -673,11 +688,10 @@ class SpackEnv(UberEnv):
 
         return exe
 
-    # Returns version of Spack being used as Version type
-    # https://packaging.pypa.io/en/latest/version.html#packaging.version.Version
+    # Returns version of Spack
     def spack_version(self):
         _, out = sexe(f"{self.spack_exe()} -V", ret_output=True)
-        return Version(out.split()[0])
+        return out.split()[0]
 
     def check_concretizer_args(self):
         cmd = "{0} help install".format(self.spack_exe(use_spack_env=False))
@@ -987,7 +1001,7 @@ class SpackEnv(UberEnv):
             print("[ERROR: Failed to update git reference for builtin package repository]")
             sys.exit(-1)
 
-        if self.spack_version() >= Version("1.1.0"):
+        if version2tuple(self.spack_version()) >= version2tuple("1.1.0"):
             if self.spack_compiler_mixing:
                 print(f"[enabling mixing compilers in Spack]\n")
                 res = sexe(f"{self.spack_exe()} config --scope=env:{self.spack_env_directory} add concretizer:compiler_mixing:True")

--- a/uberenv.py
+++ b/uberenv.py
@@ -690,7 +690,7 @@ class SpackEnv(UberEnv):
 
     # Returns version of Spack
     def spack_version(self):
-        _, out = sexe(f"{self.spack_exe()} -V", ret_output=True)
+        _, out = sexe('{0} --version'.format(self.spack_exe(use_spack_env=False)), ret_output=True)
         return out.split()[0]
 
     def check_concretizer_args(self):

--- a/uberenv.py
+++ b/uberenv.py
@@ -688,9 +688,9 @@ class SpackEnv(UberEnv):
 
         return exe
 
-    # Returns version of Spack
+    # Returns version of Spack being used
     def spack_version(self):
-        _, out = sexe('{0} --version'.format(self.spack_exe(use_spack_env=False)), ret_output=True)
+        res, out = sexe('{0} --version'.format(self.spack_exe(use_spack_env=False)), ret_output=True)
         return out.split()[0]
 
     def check_concretizer_args(self):
@@ -1098,7 +1098,7 @@ class SpackEnv(UberEnv):
 
     def show_info(self):
         # print version of spack
-        print("[spack version: {0}]".format(str(self.spack_version())))
+        print("[spack version: {0}]".format(self.spack_version()))
 
         # print concretized spec with install info
         # default case prints install status and 32 characters hash

--- a/uberenv.py
+++ b/uberenv.py
@@ -313,12 +313,12 @@ def parse_args():
                       default=None,
                       help="Path to Spack Environment file (e.g. spack.yaml or spack.lock)")
 
-    # Enable compiler mixing argument (Spack 1.1.0+ only)
-    parser.add_argument("--spack-compiler-mixing",
-                      dest="spack_compiler_mixing",
+    # Disable compiler mixing argument (Spack 1.1.0+ only)
+    parser.add_argument("--spack-disable-compiler-mixing",
+                      dest="spack_disable_compiler_mixing",
                       default=False,
                       action="store_true",
-                      help="Enables compiler mixing (Spack 1.1.0+ only)")
+                      help="Disables compiler mixing (Spack 1.1.0+ only)")
 
     ###############
     # parse args
@@ -685,7 +685,7 @@ class SpackEnv(UberEnv):
         self.build_mode = self.set_from_args_or_json("spack_build_mode", True)
         self.spack_externals = self.set_from_args_or_json("spack_externals", True)
         self.spack_compiler_paths = self.set_from_args_or_json("spack_compiler_paths", True)
-        self.spack_compiler_mixing = self.set_from_args_or_json("spack_compiler_mixing", True)
+        self.spack_disable_compiler_mixing = self.set_from_args_or_json("spack_disable_compiler_mixing", True)
 
         # default spack build mode is dev-build
         if self.build_mode is None:
@@ -1069,11 +1069,8 @@ class SpackEnv(UberEnv):
             sys.exit(-1)
 
         if version2tuple(self.spack_version()) >= version2tuple("1.1.0"):
-            if self.spack_compiler_mixing:
-                print(f"[enabling mixing compilers in Spack]\n")
-                res = sexe(f"{self.spack_exe()} config --scope=env:{self.spack_env_directory} add concretizer:compiler_mixing:True")
-            else:
-                print(f"[disabling mixing compilers in Spack]\n")
+            if self.spack_disable_compiler_mixing:
+                print(f"[disabling mixing compilers in Spack]")
                 res = sexe(f"{self.spack_exe()} config --scope=env:{self.spack_env_directory} add concretizer:compiler_mixing:False")
             if res != 0:
                 print("[ERROR: Failed to configure compiler mixing in Spack]")

--- a/uberenv.py
+++ b/uberenv.py
@@ -313,12 +313,12 @@ def parse_args():
                       default=None,
                       help="Path to Spack Environment file (e.g. spack.yaml or spack.lock)")
 
-    # Disable compiler mixing argument (Spack 1.1.0+ only)
-    parser.add_argument("--spack-disable-compiler-mixing",
-                      dest="spack_disable_compiler_mixing",
+    # Enable compiler mixing (Spack 1.1.0+ only)
+    parser.add_argument("--spack-allow-compiler-mixing",
+                      dest="spack_allow_compiler_mixing",
                       default=False,
                       action="store_true",
-                      help="Disables compiler mixing (Spack 1.1.0+ only)")
+                      help="Enables compiler mixing (Spack 1.1.0+ only)")
 
     ###############
     # parse args
@@ -685,7 +685,7 @@ class SpackEnv(UberEnv):
         self.build_mode = self.set_from_args_or_json("spack_build_mode", True)
         self.spack_externals = self.set_from_args_or_json("spack_externals", True)
         self.spack_compiler_paths = self.set_from_args_or_json("spack_compiler_paths", True)
-        self.spack_disable_compiler_mixing = self.set_from_args_or_json("spack_disable_compiler_mixing", True)
+        self.spack_allow_compiler_mixing = self.set_from_args_or_json("spack_allow_compiler_mixing", True)
 
         # default spack build mode is dev-build
         if self.build_mode is None:
@@ -1069,7 +1069,10 @@ class SpackEnv(UberEnv):
             sys.exit(-1)
 
         if version2tuple(self.spack_version()) >= version2tuple("1.1.0"):
-            if self.spack_disable_compiler_mixing:
+            if self.spack_allow_compiler_mixing:
+                print(f"[enabling mixing compilers in Spack]")
+                res = sexe(f"{self.spack_exe()} config --scope=env:{self.spack_env_directory} add concretizer:compiler_mixing:True")
+            else:
                 print(f"[disabling mixing compilers in Spack]")
                 res = sexe(f"{self.spack_exe()} config --scope=env:{self.spack_env_directory} add concretizer:compiler_mixing:False")
             if res != 0:

--- a/uberenv.py
+++ b/uberenv.py
@@ -64,7 +64,6 @@ import re
 import argparse
 
 from functools import partial
-from packaging.version import Version
 
 from os import environ as env
 from os.path import join as pjoin
@@ -386,6 +385,23 @@ def find_project_config(args):
                 lookup_path = pabs(os.path.join(lookup_path, os.pardir))
     print("ERROR: No Uberenv configuration json file found")
     sys.exit(-1)
+
+def version2tuple(version: str) -> tuple[int, int, int]:
+    """
+    Converts version string (major.minor.patch.other) to tuple (major, minor, patch).
+    Add missing 0's if not all three version numbers are supplied (e.g. "1" -> (1, 0, 0))
+
+    Example usage:
+    version2tuple(self.spack_version()) >= version2tuple("1.2.0")
+
+    :param version: Version string (major.minor.patch.other)
+    :type version: str
+    """
+    raw_parts = version.split(".")[:3]
+    parts = [p if p != "" else "0" for p in raw_parts]
+    parts += ["0"] * (3 - len(parts))
+    return tuple(map(int, parts))
+
 
 class UberEnv():
     """ Base class for package manager """
@@ -1052,7 +1068,7 @@ class SpackEnv(UberEnv):
             print("[ERROR: Failed to update git reference for builtin package repository]")
             sys.exit(-1)
 
-        if Version(self.spack_version()) >= Version("1.1.0"):
+        if version2tuple(self.spack_version()) >= version2tuple("1.1.0"):
             if self.spack_compiler_mixing:
                 print(f"[enabling mixing compilers in Spack]\n")
                 res = sexe(f"{self.spack_exe()} config --scope=env:{self.spack_env_directory} add concretizer:compiler_mixing:True")

--- a/uberenv.py
+++ b/uberenv.py
@@ -64,6 +64,7 @@ import re
 import argparse
 
 from functools import partial
+from packaging.version import Version
 
 from os import environ as env
 from os.path import join as pjoin
@@ -385,23 +386,6 @@ def find_project_config(args):
                 lookup_path = pabs(os.path.join(lookup_path, os.pardir))
     print("ERROR: No Uberenv configuration json file found")
     sys.exit(-1)
-
-def version2tuple(version: str) -> tuple[int, int, int]:
-    """
-    Converts version string (major.minor.patch.other) to tuple (major, minor, patch).
-    Add missing 0's if not all three version numbers are supplied (e.g. "1" -> (1, 0, 0))
-
-    Example usage:
-    version2tuple(self.spack_version()) >= version2tuple("1.2.0")
-
-    :param version: Version string (major.minor.patch.other)
-    :type version: str
-    """
-    raw_parts = version.split(".")[:3]
-    parts = [p if p != "" else "0" for p in raw_parts]
-    parts += ["0"] * (3 - len(parts))
-    return tuple(map(int, parts))
-
 
 class UberEnv():
     """ Base class for package manager """
@@ -1068,7 +1052,7 @@ class SpackEnv(UberEnv):
             print("[ERROR: Failed to update git reference for builtin package repository]")
             sys.exit(-1)
 
-        if version2tuple(self.spack_version()) >= version2tuple("1.1.0"):
+        if Version(self.spack_version()) >= Version("1.1.0"):
             if self.spack_compiler_mixing:
                 print(f"[enabling mixing compilers in Spack]\n")
                 res = sexe(f"{self.spack_exe()} config --scope=env:{self.spack_env_directory} add concretizer:compiler_mixing:True")


### PR DESCRIPTION
Adds option `--spack-allow-compiler-mixing`. If left unset, Uberenv will disable compiler mixing by default.

More info:

* https://spack.readthedocs.io/en/latest/configuring_compilers.html#mixing-compilers
* https://github.com/spack/spack/pull/51135