### PR TITLE
Enables setting vcpkg package features

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -26,6 +26,8 @@ The Uberenv project release numbers follow [Semantic Versioning](http://semver.o
   to `false` in `.uberenv_config.json`.
 - Adds the `--spack-debug` option to run spack spec/install commands in debug mode.
 - Adds the `--spack-allow-deprecated` option, to allow spack to build packages marked deprecated.
+- vcpkg: Adds the `--vcpkg-features` option to enable a comma- or semicolon- separated list of `features` to the installed package. Features are the vcpkg analog of spack `variants`.
+- vcpkg: Adds the `--vcpkg-cuda-architectures` option to append a specific `CMAKE_CUDA_ARCHICTURES` to the host-config
 
 ### Changed
 - All spack specs are now expressed inside single quotes to protect the parsing of complex flags.

--- a/uberenv.py
+++ b/uberenv.py
@@ -155,6 +155,18 @@ def parse_args():
                       default=None,
                       help="dir with vckpkg ports")
 
+    # optional vcpkg feature list for the package
+    parser.add_argument("--vcpkg-features",
+                      dest="vcpkg_features",
+                      default=None,
+                      help="comma-separated vcpkg features to enable for the package")
+
+    # optional CUDA architecture list for vcpkg CUDA builds
+    parser.add_argument("--vcpkg-cuda-architectures",
+                      dest="vcpkg_cuda_architectures",
+                      default=None,
+                      help="semicolon- or comma-separated CUDA architectures for vcpkg CUDA builds")
+
     # overrides package_name
     parser.add_argument("--package-name",
                       dest="package_name",
@@ -469,6 +481,41 @@ class VcpkgEnv(UberEnv):
         if self.vcpkg_triplet is None:
            self.vcpkg_triplet = os.getenv("VCPKG_DEFAULT_TRIPLET", "x86-windows")
 
+        self.vcpkg_features = self.set_from_args_or_json("vcpkg_features", True)
+        self.vcpkg_package_name = self.pkg_name.split("[", 1)[0]
+        self.vcpkg_package_spec = self.make_vcpkg_package_spec()
+        if self.vcpkg_package_spec != self.pkg_name:
+            print("Vcpkg package spec: {}".format(self.vcpkg_package_spec))
+
+        self.vcpkg_cuda_architectures = self.set_from_args_or_json("vcpkg_cuda_architectures", True)
+        if self.vcpkg_cuda_architectures:
+            self.vcpkg_cuda_architectures = str(self.vcpkg_cuda_architectures).replace(",", ";")
+            os.environ["CUDA_ARCHITECTURES"] = self.vcpkg_cuda_architectures
+            print("Vcpkg CUDA architectures: {}".format(self.vcpkg_cuda_architectures))
+
+    def make_vcpkg_package_spec(self):
+        """ Return the package spec, with optional vcpkg features. """
+        if "[" in self.pkg_name:
+            return self.pkg_name
+
+        features = self.normalized_vcpkg_features()
+        if features:
+            return "{0}[{1}]".format(self.pkg_name, ",".join(features))
+
+        return self.pkg_name
+
+    def normalized_vcpkg_features(self):
+        """ Normalize config or command-line vcpkg feature settings. """
+        if self.vcpkg_features is None:
+            return []
+
+        if isinstance(self.vcpkg_features, str):
+            features = re.split(r"[,;]", self.vcpkg_features)
+        else:
+            features = self.vcpkg_features
+
+        return [str(feature).strip() for feature in features if str(feature).strip()]
+
     def setup_paths_and_dirs(self):
         # get the current working path, and the glob used to identify the
         # package files we want to hot-copy to vcpkg
@@ -561,10 +608,10 @@ class VcpkgEnv(UberEnv):
     def show_info(self):
         os.chdir(self.dest_vcpkg)
         print("[info: Details for package '{0}']".format(self.pkg_name))
-        sexe("vcpkg.exe search " + self.pkg_name, echo=True)
+        sexe("vcpkg.exe search " + self.vcpkg_package_name, echo=True)
 
         print("[info: Dependencies for package '{0}']".format(self.pkg_name))
-        sexe("vcpkg.exe depend-info " + self.pkg_name, echo=True)
+        sexe("vcpkg.exe depend-info " + self.vcpkg_package_spec, echo=True)
 
     def create_mirror(self):
         pass
@@ -576,13 +623,13 @@ class VcpkgEnv(UberEnv):
 
         os.chdir(self.dest_vcpkg)
         install_cmd = "vcpkg.exe "
-        install_cmd += "install {0}:{1}".format(self.pkg_name, self.vcpkg_triplet)
+        install_cmd += "install {0}:{1}".format(self.vcpkg_package_spec, self.vcpkg_triplet)
 
         res = sexe(install_cmd, echo=True)
 
         # Running the install_cmd eventually generates the host config file,
         # which we copy to the target directory.
-        src_hc = pjoin(self.dest_vcpkg, "installed", self.vcpkg_triplet, "include", self.pkg_name, "hc.cmake")
+        src_hc = pjoin(self.dest_vcpkg, "installed", self.vcpkg_triplet, "include", self.vcpkg_package_name, "hc.cmake")
         hcfg_fname = pjoin(self.dest_dir, "{0}.{1}.cmake".format(platform.uname()[1], self.vcpkg_triplet))
         print("[info: copying host config file to {0}]".format(hcfg_fname))
         shutil.copy(os.path.abspath(src_hc), hcfg_fname)

--- a/uberenv.py
+++ b/uberenv.py
@@ -623,7 +623,7 @@ class VcpkgEnv(UberEnv):
 
         os.chdir(self.dest_vcpkg)
         install_cmd = "vcpkg.exe "
-        install_cmd += "install {0}:{1}".format(self.vcpkg_package_spec, self.vcpkg_triplet)
+        install_cmd += "install {0}:{1} --recurse".format(self.vcpkg_package_spec, self.vcpkg_triplet)
 
         res = sexe(install_cmd, echo=True)
 

--- a/uberenv.py
+++ b/uberenv.py
@@ -626,6 +626,9 @@ class VcpkgEnv(UberEnv):
         install_cmd += "install {0}:{1} --recurse".format(self.vcpkg_package_spec, self.vcpkg_triplet)
 
         res = sexe(install_cmd, echo=True)
+        if res != 0:
+            print("[ERROR: vcpkg install failed with returncode {0}]".format(res))
+            return res
 
         # Running the install_cmd eventually generates the host config file,
         # which we copy to the target directory.

--- a/uberenv.py
+++ b/uberenv.py
@@ -636,9 +636,18 @@ class VcpkgEnv(UberEnv):
         hcfg_fname = pjoin(self.dest_dir, "{0}.{1}.cmake".format(platform.uname()[1], self.vcpkg_triplet))
         print("[info: copying host config file to {0}]".format(hcfg_fname))
         shutil.copy(os.path.abspath(src_hc), hcfg_fname)
+        self.patch_host_config(hcfg_fname)
         print("")
         print("[install complete!]")
         return res
+
+    def patch_host_config(self, hcfg_fname):
+        """ Apply uberenv command-line settings to the copied host-config. """
+        if self.vcpkg_cuda_architectures:
+            with open(hcfg_fname, "a") as hcfg:
+                hcfg.write("\n# CUDA architecture requested through uberenv/vcpkg\n")
+                hcfg.write('set(CMAKE_CUDA_ARCHITECTURES "{0}" CACHE STRING "" FORCE)\n'
+                           .format(self.vcpkg_cuda_architectures))
 
 
 class SpackEnv(UberEnv):


### PR DESCRIPTION
* This branch adds the ability to enable vcpkg features through the command line via `--vcpkg-features` (roughly equivalent to spack variants).
  * The vcpkg syntax is `vcpkg install foo[bar]` to enable feature `bar` for package `foo`
  * I modified the install line to include `--recurse` which allows reinstalling already built dependencies
  * We also now check the return code from installation and print and error message if it is nonzero.
* I also added a command line argument to set the CUDA arch flags: `--vcpkg-cuda-architectures`.

Given the above two features, I am using this generate vcpkg TPLs for a cuda-enabled axom (in a forthcoming PR to Axom).  